### PR TITLE
gm/expansion-btc_btc-weth_weth

### DIFF
--- a/deploy/GlvToken.ts
+++ b/deploy/GlvToken.ts
@@ -31,6 +31,12 @@ const deploy: DeployFunction = async (hre) => {
     const { marketPairKey, marketPairConfig } = await getDeployConfig()
     const glvConfig = marketPairConfig.GLV
 
+    // Skip if GLV token is not configured for this market pair
+    if (!glvConfig) {
+        console.log(`⏭️  Skipping GLV deployment - GLV token not configured for ${marketPairKey}`)
+        return
+    }
+
     const eid = hre.network.config.eid as EndpointId
     const networkName = hre.network.name
 

--- a/deploy/MarketToken.ts
+++ b/deploy/MarketToken.ts
@@ -31,6 +31,12 @@ const deploy: DeployFunction = async (hre) => {
     const { marketPairKey, marketPairConfig } = await getDeployConfig()
     const gmConfig = marketPairConfig.GM
 
+    // Skip if GM token is not configured for this market pair
+    if (!gmConfig) {
+        console.log(`⏭️  Skipping GM deployment - GM token not configured for ${marketPairKey}`)
+        return
+    }
+
     const eid = hre.network.config.eid as EndpointId
     const networkName = hre.network.name
 

--- a/deployments/arbitrum-mainnet/MarketToken_Adapter_BTC_BTC.json
+++ b/deployments/arbitrum-mainnet/MarketToken_Adapter_BTC_BTC.json
@@ -1,0 +1,1695 @@
+{
+  "address": "0x661E1faD17124471a59c37E9c4590BA809599f30",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xafabe3407bfe99a3ed397091d1d1936eaeb7c85d52428494b5ea00e387443002",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x661E1faD17124471a59c37E9c4590BA809599f30",
+    "transactionIndex": 3,
+    "gasUsed": "2507009",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800100001000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000001000000000000000080000000000000000000020000000000000000000800000100000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000400000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x356959ff5f8876c93bb9b8bae195d11947d9145d8e08b34de57a26271d06fd99",
+    "transactionHash": "0xafabe3407bfe99a3ed397091d1d1936eaeb7c85d52428494b5ea00e387443002",
+    "logs": [
+      {
+        "transactionIndex": 3,
+        "blockNumber": 409378950,
+        "transactionHash": "0xafabe3407bfe99a3ed397091d1d1936eaeb7c85d52428494b5ea00e387443002",
+        "address": "0x661E1faD17124471a59c37E9c4590BA809599f30",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 0,
+        "blockHash": "0x356959ff5f8876c93bb9b8bae195d11947d9145d8e08b34de57a26271d06fd99"
+      },
+      {
+        "transactionIndex": 3,
+        "blockNumber": 409378950,
+        "transactionHash": "0xafabe3407bfe99a3ed397091d1d1936eaeb7c85d52428494b5ea00e387443002",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x000000000000000000000000661e1fad17124471a59c37e9c4590ba809599f3000000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 1,
+        "blockHash": "0x356959ff5f8876c93bb9b8bae195d11947d9145d8e08b34de57a26271d06fd99"
+      }
+    ],
+    "blockNumber": 409378950,
+    "cumulativeGasUsed": "2582569",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "0x7C11F78Ce78768518D743E81Fdfa2F860C6b9A77",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.WARNING: ONLY 1 of these should exist for a given global mesh, unless you make a NON-default implementation of GM and needs to be done very carefully.WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out. IF the 'innerToken' applies something like a transfer fee, the default will NOT work... a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\",\"errors\":{\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}}},\"kind\":\"dev\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"approvalRequired()\":{\"details\":\"In the case of default OFTAdapter, approval is required.In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.\",\"returns\":{\"_0\":\"The address of the adapted ERC-20 token.\"}},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"title\":\"MarketToken_Adapter Contract\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_Adapter.sol\":\"MarketToken_Adapter\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTAdapter.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20Metadata, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\\\";\\nimport { SafeERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFTAdapter Contract\\n * @dev OFTAdapter is a contract that adapts an ERC-20 token to the OFT functionality.\\n *\\n * @dev For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.\\n * @dev WARNING: ONLY 1 of these should exist for a given global mesh,\\n * unless you make a NON-default implementation of OFT and needs to be done very carefully.\\n * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n * a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\\n */\\nabstract contract OFTAdapter is OFTCore {\\n    using SafeERC20 for IERC20;\\n\\n    IERC20 internal immutable innerToken;\\n\\n    /**\\n     * @dev Constructor for the OFTAdapter contract.\\n     * @param _token The address of the ERC-20 token to be adapted.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        address _token,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFTCore(IERC20Metadata(_token).decimals(), _lzEndpoint, _delegate) {\\n        innerToken = IERC20(_token);\\n    }\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the adapted ERC-20 token.\\n     *\\n     * @dev In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(innerToken);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of default OFTAdapter, approval is required.\\n     * @dev In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Locks tokens from the sender's specified balance in this contract.\\n     * @param _from The address to debit from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev msg.sender will need to approve this _amountLD of tokens to be locked inside of the contract.\\n     * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n     * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n     * a pre/post balance check will need to be done to calculate the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n        // @dev Lock tokens by moving them into this contract from the caller.\\n        innerToken.safeTransferFrom(_from, address(this), amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     *\\n     * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n     * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n     * a pre/post balance check will need to be done to calculate the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        // @dev Unlock the tokens and transfer to the recipient.\\n        innerToken.safeTransfer(_to, _amountLD);\\n        // @dev In the case of NON-default OFTAdapter, the amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xd65041c093c19792b66369a04b4aea5c988c32e2cf4ab952a442315426407fd0\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_Adapter.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { OFTAdapter } from \\\"@layerzerolabs/oft-evm/contracts/OFTAdapter.sol\\\";\\n\\n/**\\n * @title MarketToken_Adapter Contract\\n * @dev MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.\\n *\\n * @dev For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.\\n * @dev WARNING: ONLY 1 of these should exist for a given global mesh,\\n * unless you make a NON-default implementation of GM and needs to be done very carefully.\\n * @dev WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n * a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\\n */\\ncontract MarketToken_Adapter is OFTAdapter {\\n    constructor(\\n        address _token,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFTAdapter(_token, _lzEndpoint, _delegate) Ownable(_delegate) {}\\n}\\n\",\"keccak256\":\"0xd6457a4a2e8e110dced051d22732dc78ab3d72822949f99a2b1a2d7cd0cca924\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x60e06040523480156200001157600080fd5b5060405162002fbc38038062002fbc833981016040819052620000349162000254565b828282826001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa15801562000076573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906200009c91906200029e565b8282818181818a6001600160a01b038116620000d257604051631e4fbdf760e01b81526000600482015260240160405180910390fd5b620000dd81620001e2565b506001600160a01b0380831660805281166200010c57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200015457600080fd5b505af115801562000169573d6000803e3d6000fd5b5050505050505050620001816200023260201b60201c565b60ff168360ff161015620001a8576040516301e9714b60e41b815260040160405180910390fd5b620001b5600684620002e0565b620001c290600a620003ff565b60a0525050506001600160a01b0390921660c05250620004109350505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b80516001600160a01b03811681146200024f57600080fd5b919050565b6000806000606084860312156200026a57600080fd5b620002758462000237565b9250620002856020850162000237565b9150620002956040850162000237565b90509250925092565b600060208284031215620002b157600080fd5b815160ff81168114620002c357600080fd5b9392505050565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620002fc57620002fc620002ca565b92915050565b600181815b8085111562000343578160001904821115620003275762000327620002ca565b808516156200033557918102915b93841c939080029062000307565b509250929050565b6000826200035c57506001620002fc565b816200036b57506000620002fc565b81600181146200038457600281146200038f57620003af565b6001915050620002fc565b60ff841115620003a357620003a3620002ca565b50506001821b620002fc565b5060208310610133831016604e8410600b8410161715620003d4575081810a620002fc565b620003e0838362000302565b8060001904821115620003f757620003f7620002ca565b029392505050565b6000620002c360ff8416836200034b565b60805160a05160c051612b2862000494600039600081816106690152818161174701526118b90152600081816104e20152818161168e0152818161170a01526117fa0152600081816103e40152818161084001528181610e4f015281816110b4015281816113410152818161191d01528181611ac40152611b7d0152612b286000f3fe6080604052600436106101ee5760003560e01c806382413eac1161010d578063bc70b354116100a0578063d045a0dc1161006f578063d045a0dc14610607578063d42438851461061a578063f2fde38b1461063a578063fc0c546a1461065a578063ff7bd03d1461068d57600080fd5b8063bc70b35414610593578063bd815db0146105b3578063c7c7f5b3146105c6578063ca5eb5e1146105e757600080fd5b80639f68b964116100dc5780639f68b96414610512578063b731ea0a14610526578063b98bd07014610546578063bb0b6a531461056657600080fd5b806382413eac14610476578063857749b0146104965780638da5cb5b146104b2578063963efcaa146104d057600080fd5b80633b6f743b116101855780635e280f11116101545780635e280f11146103d25780636fc1b31e14610406578063715018a6146104265780637d25a05e1461043b57600080fd5b80633b6f743b1461031e57806352ae28791461034b5780635535d4611461035e5780635a0dfe4d1461038b57600080fd5b8063156a0d0f116101c1578063156a0d0f146102a057806317442b70146102c75780631f5e1334146102e95780633400288b146102fe57600080fd5b80630d35b415146101f3578063111ecdad1461022b57806313137d6514610263578063134d4f2514610278575b600080fd5b3480156101ff57600080fd5b5061021361020e366004611c72565b6106ad565b60405161022293929190611cf6565b60405180910390f35b34801561023757600080fd5b5060045461024b906001600160a01b031681565b6040516001600160a01b039091168152602001610222565b610276610271366004611dfe565b61083e565b005b34801561028457600080fd5b5061028d600281565b60405161ffff9091168152602001610222565b3480156102ac57600080fd5b506040805162b9270b60e21b81526001602082015201610222565b3480156102d357600080fd5b5060408051600181526002602082015201610222565b3480156102f557600080fd5b5061028d600181565b34801561030a57600080fd5b50610276610319366004611eb6565b6108fe565b34801561032a57600080fd5b5061033e610339366004611eee565b610914565b6040516102229190611f3f565b34801561035757600080fd5b503061024b565b34801561036a57600080fd5b5061037e610379366004611f68565b61097d565b6040516102229190611f9b565b34801561039757600080fd5b506103c26103a6366004611eb6565b63ffffffff919091166000908152600160205260409020541490565b6040519015158152602001610222565b3480156103de57600080fd5b5061024b7f000000000000000000000000000000000000000000000000000000000000000081565b34801561041257600080fd5b50610276610421366004611fae565b610a22565b34801561043257600080fd5b50610276610a7f565b34801561044757600080fd5b5061045e610456366004611eb6565b600092915050565b6040516001600160401b039091168152602001610222565b34801561048257600080fd5b506103c2610491366004611fcb565b610a93565b3480156104a257600080fd5b5060405160068152602001610222565b3480156104be57600080fd5b506000546001600160a01b031661024b565b3480156104dc57600080fd5b506105047f000000000000000000000000000000000000000000000000000000000000000081565b604051908152602001610222565b34801561051e57600080fd5b5060016103c2565b34801561053257600080fd5b5060025461024b906001600160a01b031681565b34801561055257600080fd5b50610276610561366004612075565b610aa8565b34801561057257600080fd5b506105046105813660046120b6565b60016020526000908152604090205481565b34801561059f57600080fd5b5061037e6105ae3660046120d1565b610ac2565b6102766105c1366004612075565b610c6a565b6105d96105d4366004612131565b610df4565b60405161022292919061219e565b3480156105f357600080fd5b50610276610602366004611fae565b610e28565b610276610615366004611dfe565b610eae565b34801561062657600080fd5b50610276610635366004611fae565b610edd565b34801561064657600080fd5b50610276610655366004611fae565b610f33565b34801561066657600080fd5b507f000000000000000000000000000000000000000000000000000000000000000061024b565b34801561069957600080fd5b506103c26106a83660046121f0565b610f71565b604080518082019091526000808252602082015260606106e0604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610721573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610745919061220c565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610782573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107a69190612229565b604080518082018252848152602080820184905282516000808252918101909352909750919250906107fb565b6040805180820190915260008152606060208201528152602001906001900390816107d35790505b509350600080610820604089013560608a013561081b60208c018c6120b6565b610fa7565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316331461088e576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b602087018035906108a8906108a3908a6120b6565b610fe3565b146108e6576108ba60208801886120b6565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610885565b6108f58787878787878761101f565b50505050505050565b610906611186565b61091082826111b3565b5050565b604080518082019091526000808252602082015260006109446040850135606086013561081b60208801886120b6565b9150506000806109548684611208565b909250905061097161096960208801886120b6565b83838861132b565b93505050505b92915050565b6003602090815260009283526040808420909152908252902080546109a190612258565b80601f01602080910402602001604051908101604052809291908181526020018280546109cd90612258565b8015610a1a5780601f106109ef57610100808354040283529160200191610a1a565b820191906000526020600020905b8154815290600101906020018083116109fd57829003601f168201915b505050505081565b610a2a611186565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610a87611186565b610a91600061140c565b565b6001600160a01b03811630145b949350505050565b610ab0611186565b610910610abd828461232d565b61145c565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610af690612258565b80601f0160208091040260200160405190810160405280929190818152602001828054610b2290612258565b8015610b6f5780601f10610b4457610100808354040283529160200191610b6f565b820191906000526020600020905b815481529060010190602001808311610b5257829003601f168201915b505050505090508051600003610bbf5783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610aa09350505050565b6000839003610bcf579050610aa0565b60028310610c4d57610c1684848080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061156392505050565b80610c248460028188612442565b604051602001610c369392919061246c565b604051602081830303815290604052915050610aa0565b8383604051639a6d49cd60e01b81526004016108859291906124bd565b60005b81811015610d735736838383818110610c8857610c886124d1565b9050602002810190610c9a91906124e7565b9050610ccd610cac60208301836120b6565b602083013563ffffffff919091166000908152600160205260409020541490565b610cd75750610d6b565b3063d045a0dc60c08301358360a0810135610cf6610100830183612508565b610d07610100890160e08a01611fae565b610d156101208a018a612508565b6040518963ffffffff1660e01b8152600401610d379796959493929190612563565b6000604051808303818588803b158015610d5057600080fd5b505af1158015610d64573d6000803e3d6000fd5b5050505050505b600101610c6d565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa158015610db2573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052610dda91908101906125e9565b604051638351eea760e01b81526004016108859190611f9b565b610dfc611c13565b6040805180820190915260008082526020820152610e1b85858561158f565b915091505b935093915050565b610e30611186565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b158015610e9357600080fd5b505af1158015610ea7573d6000803e3d6000fd5b5050505050565b333014610ece5760405163029a949d60e31b815260040160405180910390fd5b6108f5878787878787876108e6565b610ee5611186565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610a74565b610f3b611186565b6001600160a01b038116610f6557604051631e4fbdf760e01b815260006004820152602401610885565b610f6e8161140c565b50565b6000602082018035906001908390610f8990866120b6565b63ffffffff1681526020810191909152604001600020541492915050565b600080610fb38561168a565b915081905083811015610e20576040516371c4efed60e01b81526004810182905260248101859052604401610885565b63ffffffff8116600090815260016020526040812054806109775760405163f6ff4fb760e01b815263ffffffff84166004820152602401610885565b600061103161102e87876116c1565b90565b9050600061105d8261104b6110468a8a6116e0565b611703565b61105860208d018d6120b6565b611738565b9050602886111561112457600061109a61107d60608c0160408d01612656565b61108a60208d018d6120b6565b846110958c8c611776565b6117c1565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906110f09086908d906000908790600401612673565b600060405180830381600087803b15801561110a57600080fd5b505af115801561111e573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61115d60208d018d6120b6565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6000546001600160a01b03163314610a915760405163118cdaa760e01b8152336004820152602401610885565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6060806000611265856020013561121e866117f3565b61122b60a0890189612508565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061181f92505050565b909350905060008161127857600161127b565b60025b905061129b61128d60208801886120b6565b826105ae60808a018a612508565b6004549093506001600160a01b031680156113215760405163043a78eb60e01b81526001600160a01b0382169063043a78eb906112de90889088906004016126ae565b602060405180830381865afa1580156112fb573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061131f91906126d3565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff16815260200161138e89610fe3565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b81526004016113c39291906126f0565b6040805180830381865afa1580156113df573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906114039190612799565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60005b81518110156115335761148e82828151811061147d5761147d6124d1565b602002602001015160400151611563565b8181815181106114a0576114a06124d1565b602002602001015160400151600360008484815181106114c2576114c26124d1565b60200260200101516000015163ffffffff1663ffffffff16815260200190815260200160002060008484815181106114fc576114fc6124d1565b60200260200101516020015161ffff1661ffff168152602001908152602001600020908161152a9190612805565b5060010161145f565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610a7491906128c4565b600281015161ffff81166003146109105781604051639a6d49cd60e01b81526004016108859190611f9b565b611597611c13565b60408051808201909152600080825260208201526000806115ce33604089013560608a01356115c960208c018c6120b6565b611899565b915091506000806115df8984611208565b909250905061160b6115f460208b018b6120b6565b8383611605368d90038d018d61294f565b8b6118ea565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611659908d018d6120b6565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b60007f00000000000000000000000000000000000000000000000000000000000000006116b78184612981565b61097791906129a3565b60006116d06020828486612442565b6116d9916129c8565b9392505050565b60006116f0602860208486612442565b6116f9916129e6565b60c01c9392505050565b60006109777f00000000000000000000000000000000000000000000000000000000000000006001600160401b0384166129a3565b600061176e6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001685856119f5565b509092915050565b60606117858260288186612442565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016117da9493929190612a16565b6040516020818303038152906040529050949350505050565b60006109777f000000000000000000000000000000000000000000000000000000000000000083612981565b805160609015158061186857848460405160200161185492919091825260c01b6001600160c01b031916602082015260280190565b60405160208183030381529060405261188f565b8484338560405160200161187f9493929190612a65565b6040516020818303038152906040525b9150935093915050565b6000806118a7858585610fa7565b90925090506118e16001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016873085611a59565b94509492505050565b6118f2611c13565b60006119018460000151611a98565b60208501519091501561191b5761191b8460200151611ac0565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff16815260200161196b8c610fe3565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b81526004016119a79291906126f0565b60806040518083038185885af11580156119c5573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906119ea9190612aa8565b979650505050505050565b6040516001600160a01b03838116602483015260448201839052611a5491859182169063a9059cbb906064015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050611ba2565b505050565b6040516001600160a01b038481166024830152838116604483015260648201839052611a929186918216906323b872dd90608401611a22565b50505050565b6000813414611abc576040516304fb820960e51b8152346004820152602401610885565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b20573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b44919061220c565b90506001600160a01b038116611b6d576040516329b99a9560e11b815260040160405180910390fd5b6109106001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085611a59565b600080602060008451602086016000885af180611bc5576040513d6000823e3d81fd5b50506000513d91508115611bdd578060011415611bea565b6001600160a01b0384163b155b15611a9257604051635274afe760e01b81526001600160a01b0385166004820152602401610885565b60405180606001604052806000801916815260200160006001600160401b03168152602001611c55604051806040016040528060008152602001600081525090565b905290565b600060e08284031215611c6c57600080fd5b50919050565b600060208284031215611c8457600080fd5b81356001600160401b03811115611c9a57600080fd5b610aa084828501611c5a565b60005b83811015611cc1578181015183820152602001611ca9565b50506000910152565b60008151808452611ce2816020860160208601611ca6565b601f01601f19169290920160200192915050565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b83811015611d715788870360bf19018552815180518852830151838801879052611d5e87890182611cca565b9750509382019390820190600101611d32565b50508751606088015250505060208501516080850152509050610aa0565b600060608284031215611c6c57600080fd5b60008083601f840112611db357600080fd5b5081356001600160401b03811115611dca57600080fd5b602083019150836020828501011115611de257600080fd5b9250929050565b6001600160a01b0381168114610f6e57600080fd5b600080600080600080600060e0888a031215611e1957600080fd5b611e238989611d8f565b96506060880135955060808801356001600160401b0380821115611e4657600080fd5b611e528b838c01611da1565b909750955060a08a01359150611e6782611de9565b90935060c08901359080821115611e7d57600080fd5b50611e8a8a828b01611da1565b989b979a50959850939692959293505050565b803563ffffffff81168114611eb157600080fd5b919050565b60008060408385031215611ec957600080fd5b611ed283611e9d565b946020939093013593505050565b8015158114610f6e57600080fd5b60008060408385031215611f0157600080fd5b82356001600160401b03811115611f1757600080fd5b611f2385828601611c5a565b9250506020830135611f3481611ee0565b809150509250929050565b815181526020808301519082015260408101610977565b803561ffff81168114611eb157600080fd5b60008060408385031215611f7b57600080fd5b611f8483611e9d565b9150611f9260208401611f56565b90509250929050565b6020815260006116d96020830184611cca565b600060208284031215611fc057600080fd5b81356116d981611de9565b60008060008060a08587031215611fe157600080fd5b611feb8686611d8f565b935060608501356001600160401b0381111561200657600080fd5b61201287828801611da1565b909450925050608085013561202681611de9565b939692955090935050565b60008083601f84011261204357600080fd5b5081356001600160401b0381111561205a57600080fd5b6020830191508360208260051b8501011115611de257600080fd5b6000806020838503121561208857600080fd5b82356001600160401b0381111561209e57600080fd5b6120aa85828601612031565b90969095509350505050565b6000602082840312156120c857600080fd5b6116d982611e9d565b600080600080606085870312156120e757600080fd5b6120f085611e9d565b93506120fe60208601611f56565b925060408501356001600160401b0381111561211957600080fd5b61212587828801611da1565b95989497509550505050565b6000806000838503608081121561214757600080fd5b84356001600160401b0381111561215d57600080fd5b61216987828801611c5a565b9450506040601f198201121561217e57600080fd5b50602084019150606084013561219381611de9565b809150509250925092565b600060c082019050835182526001600160401b03602085015116602083015260408401516121d9604084018280518252602090810151910152565b5082516080830152602083015160a08301526116d9565b60006060828403121561220257600080fd5b6116d98383611d8f565b60006020828403121561221e57600080fd5b81516116d981611de9565b60006020828403121561223b57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b600181811c9082168061226c57607f821691505b602082108103611c6c57634e487b7160e01b600052602260045260246000fd5b604051606081016001600160401b03811182821017156122ae576122ae612242565b60405290565b604080519081016001600160401b03811182821017156122ae576122ae612242565b604051601f8201601f191681016001600160401b03811182821017156122fe576122fe612242565b604052919050565b60006001600160401b0382111561231f5761231f612242565b50601f01601f191660200190565b60006001600160401b038084111561234757612347612242565b8360051b60206123588183016122d6565b86815291850191818101903684111561237057600080fd5b865b848110156124365780358681111561238a5760008081fd5b8801606036829003121561239e5760008081fd5b6123a661228c565b6123af82611e9d565b81526123bc868301611f56565b86820152604080830135898111156123d45760008081fd5b929092019136601f8401126123e95760008081fd5b82356123fc6123f782612306565b6122d6565b81815236898387010111156124115760008081fd5b818986018a830137600091810189019190915290820152845250918301918301612372565b50979650505050505050565b6000808585111561245257600080fd5b8386111561245f57600080fd5b5050820193919092039150565b6000845161247e818460208901611ca6565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610aa0602083018486612494565b634e487b7160e01b600052603260045260246000fd5b6000823561013e198336030181126124fe57600080fd5b9190910192915050565b6000808335601e1984360301811261251f57600080fd5b8301803591506001600160401b0382111561253957600080fd5b602001915036819003821315611de257600080fd5b6001600160401b0381168114610f6e57600080fd5b63ffffffff61257189611e9d565b168152602088013560208201526000604089013561258e8161254e565b6001600160401b03811660408401525087606083015260e060808301526125b960e083018789612494565b6001600160a01b03861660a084015282810360c08401526125db818587612494565b9a9950505050505050505050565b6000602082840312156125fb57600080fd5b81516001600160401b0381111561261157600080fd5b8201601f8101841361262257600080fd5b80516126306123f782612306565b81815285602083850101111561264557600080fd5b611403826020830160208601611ca6565b60006020828403121561266857600080fd5b81356116d98161254e565b60018060a01b038516815283602082015261ffff831660408201526080606082015260006126a46080830184611cca565b9695505050505050565b6040815260006126c16040830185611cca565b82810360208401526114038185611cca565b6000602082840312156126e557600080fd5b81516116d981611ee0565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261272660e0840182611cca565b90506060850151603f198483030160a08501526127438282611cca565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b60006040828403121561277b57600080fd5b6127836122b4565b9050815181526020820151602082015292915050565b6000604082840312156127ab57600080fd5b6116d98383612769565b601f821115611a54576000816000526020600020601f850160051c810160208610156127de5750805b601f850160051c820191505b818110156127fd578281556001016127ea565b505050505050565b81516001600160401b0381111561281e5761281e612242565b6128328161282c8454612258565b846127b5565b602080601f831160018114612867576000841561284f5750858301515b600019600386901b1c1916600185901b1785556127fd565b600085815260208120601f198616915b8281101561289657888601518255948401946001909101908401612877565b50858210156128b45787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b8381101561294157888303603f190185528151805163ffffffff1684528781015161ffff1688850152860151606087850181905261292d81860183611cca565b9689019694505050908601906001016128ed565b509098975050505050505050565b60006040828403121561296157600080fd5b6129696122b4565b82358152602083013560208201528091505092915050565b60008261299e57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761097757634e487b7160e01b600052601160045260246000fd5b8035602083101561097757600019602084900360031b1b1692915050565b6001600160c01b03198135818116916008851015612a0e5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c82015260008251612a5581602c850160208701611ca6565b91909101602c0195945050505050565b8481526001600160401b0360c01b8460c01b16602082015282602882015260008251612a98816048850160208701611ca6565b9190910160480195945050505050565b600060808284031215612aba57600080fd5b612ac261228c565b825181526020830151612ad48161254e565b6020820152612ae68460408501612769565b6040820152939250505056fea2646970667358221220a568c9db2fc2c7ad8e801ba2fa6427028f3af7cbb60ede1182bca739649792de64736f6c63430008160033",
+  "deployedBytecode": "0x6080604052600436106101ee5760003560e01c806382413eac1161010d578063bc70b354116100a0578063d045a0dc1161006f578063d045a0dc14610607578063d42438851461061a578063f2fde38b1461063a578063fc0c546a1461065a578063ff7bd03d1461068d57600080fd5b8063bc70b35414610593578063bd815db0146105b3578063c7c7f5b3146105c6578063ca5eb5e1146105e757600080fd5b80639f68b964116100dc5780639f68b96414610512578063b731ea0a14610526578063b98bd07014610546578063bb0b6a531461056657600080fd5b806382413eac14610476578063857749b0146104965780638da5cb5b146104b2578063963efcaa146104d057600080fd5b80633b6f743b116101855780635e280f11116101545780635e280f11146103d25780636fc1b31e14610406578063715018a6146104265780637d25a05e1461043b57600080fd5b80633b6f743b1461031e57806352ae28791461034b5780635535d4611461035e5780635a0dfe4d1461038b57600080fd5b8063156a0d0f116101c1578063156a0d0f146102a057806317442b70146102c75780631f5e1334146102e95780633400288b146102fe57600080fd5b80630d35b415146101f3578063111ecdad1461022b57806313137d6514610263578063134d4f2514610278575b600080fd5b3480156101ff57600080fd5b5061021361020e366004611c72565b6106ad565b60405161022293929190611cf6565b60405180910390f35b34801561023757600080fd5b5060045461024b906001600160a01b031681565b6040516001600160a01b039091168152602001610222565b610276610271366004611dfe565b61083e565b005b34801561028457600080fd5b5061028d600281565b60405161ffff9091168152602001610222565b3480156102ac57600080fd5b506040805162b9270b60e21b81526001602082015201610222565b3480156102d357600080fd5b5060408051600181526002602082015201610222565b3480156102f557600080fd5b5061028d600181565b34801561030a57600080fd5b50610276610319366004611eb6565b6108fe565b34801561032a57600080fd5b5061033e610339366004611eee565b610914565b6040516102229190611f3f565b34801561035757600080fd5b503061024b565b34801561036a57600080fd5b5061037e610379366004611f68565b61097d565b6040516102229190611f9b565b34801561039757600080fd5b506103c26103a6366004611eb6565b63ffffffff919091166000908152600160205260409020541490565b6040519015158152602001610222565b3480156103de57600080fd5b5061024b7f000000000000000000000000000000000000000000000000000000000000000081565b34801561041257600080fd5b50610276610421366004611fae565b610a22565b34801561043257600080fd5b50610276610a7f565b34801561044757600080fd5b5061045e610456366004611eb6565b600092915050565b6040516001600160401b039091168152602001610222565b34801561048257600080fd5b506103c2610491366004611fcb565b610a93565b3480156104a257600080fd5b5060405160068152602001610222565b3480156104be57600080fd5b506000546001600160a01b031661024b565b3480156104dc57600080fd5b506105047f000000000000000000000000000000000000000000000000000000000000000081565b604051908152602001610222565b34801561051e57600080fd5b5060016103c2565b34801561053257600080fd5b5060025461024b906001600160a01b031681565b34801561055257600080fd5b50610276610561366004612075565b610aa8565b34801561057257600080fd5b506105046105813660046120b6565b60016020526000908152604090205481565b34801561059f57600080fd5b5061037e6105ae3660046120d1565b610ac2565b6102766105c1366004612075565b610c6a565b6105d96105d4366004612131565b610df4565b60405161022292919061219e565b3480156105f357600080fd5b50610276610602366004611fae565b610e28565b610276610615366004611dfe565b610eae565b34801561062657600080fd5b50610276610635366004611fae565b610edd565b34801561064657600080fd5b50610276610655366004611fae565b610f33565b34801561066657600080fd5b507f000000000000000000000000000000000000000000000000000000000000000061024b565b34801561069957600080fd5b506103c26106a83660046121f0565b610f71565b604080518082019091526000808252602082015260606106e0604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610721573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610745919061220c565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610782573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107a69190612229565b604080518082018252848152602080820184905282516000808252918101909352909750919250906107fb565b6040805180820190915260008152606060208201528152602001906001900390816107d35790505b509350600080610820604089013560608a013561081b60208c018c6120b6565b610fa7565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316331461088e576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b602087018035906108a8906108a3908a6120b6565b610fe3565b146108e6576108ba60208801886120b6565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610885565b6108f58787878787878761101f565b50505050505050565b610906611186565b61091082826111b3565b5050565b604080518082019091526000808252602082015260006109446040850135606086013561081b60208801886120b6565b9150506000806109548684611208565b909250905061097161096960208801886120b6565b83838861132b565b93505050505b92915050565b6003602090815260009283526040808420909152908252902080546109a190612258565b80601f01602080910402602001604051908101604052809291908181526020018280546109cd90612258565b8015610a1a5780601f106109ef57610100808354040283529160200191610a1a565b820191906000526020600020905b8154815290600101906020018083116109fd57829003601f168201915b505050505081565b610a2a611186565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610a87611186565b610a91600061140c565b565b6001600160a01b03811630145b949350505050565b610ab0611186565b610910610abd828461232d565b61145c565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610af690612258565b80601f0160208091040260200160405190810160405280929190818152602001828054610b2290612258565b8015610b6f5780601f10610b4457610100808354040283529160200191610b6f565b820191906000526020600020905b815481529060010190602001808311610b5257829003601f168201915b505050505090508051600003610bbf5783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610aa09350505050565b6000839003610bcf579050610aa0565b60028310610c4d57610c1684848080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061156392505050565b80610c248460028188612442565b604051602001610c369392919061246c565b604051602081830303815290604052915050610aa0565b8383604051639a6d49cd60e01b81526004016108859291906124bd565b60005b81811015610d735736838383818110610c8857610c886124d1565b9050602002810190610c9a91906124e7565b9050610ccd610cac60208301836120b6565b602083013563ffffffff919091166000908152600160205260409020541490565b610cd75750610d6b565b3063d045a0dc60c08301358360a0810135610cf6610100830183612508565b610d07610100890160e08a01611fae565b610d156101208a018a612508565b6040518963ffffffff1660e01b8152600401610d379796959493929190612563565b6000604051808303818588803b158015610d5057600080fd5b505af1158015610d64573d6000803e3d6000fd5b5050505050505b600101610c6d565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa158015610db2573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052610dda91908101906125e9565b604051638351eea760e01b81526004016108859190611f9b565b610dfc611c13565b6040805180820190915260008082526020820152610e1b85858561158f565b915091505b935093915050565b610e30611186565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b158015610e9357600080fd5b505af1158015610ea7573d6000803e3d6000fd5b5050505050565b333014610ece5760405163029a949d60e31b815260040160405180910390fd5b6108f5878787878787876108e6565b610ee5611186565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610a74565b610f3b611186565b6001600160a01b038116610f6557604051631e4fbdf760e01b815260006004820152602401610885565b610f6e8161140c565b50565b6000602082018035906001908390610f8990866120b6565b63ffffffff1681526020810191909152604001600020541492915050565b600080610fb38561168a565b915081905083811015610e20576040516371c4efed60e01b81526004810182905260248101859052604401610885565b63ffffffff8116600090815260016020526040812054806109775760405163f6ff4fb760e01b815263ffffffff84166004820152602401610885565b600061103161102e87876116c1565b90565b9050600061105d8261104b6110468a8a6116e0565b611703565b61105860208d018d6120b6565b611738565b9050602886111561112457600061109a61107d60608c0160408d01612656565b61108a60208d018d6120b6565b846110958c8c611776565b6117c1565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906110f09086908d906000908790600401612673565b600060405180830381600087803b15801561110a57600080fd5b505af115801561111e573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61115d60208d018d6120b6565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6000546001600160a01b03163314610a915760405163118cdaa760e01b8152336004820152602401610885565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6060806000611265856020013561121e866117f3565b61122b60a0890189612508565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061181f92505050565b909350905060008161127857600161127b565b60025b905061129b61128d60208801886120b6565b826105ae60808a018a612508565b6004549093506001600160a01b031680156113215760405163043a78eb60e01b81526001600160a01b0382169063043a78eb906112de90889088906004016126ae565b602060405180830381865afa1580156112fb573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061131f91906126d3565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff16815260200161138e89610fe3565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b81526004016113c39291906126f0565b6040805180830381865afa1580156113df573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906114039190612799565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60005b81518110156115335761148e82828151811061147d5761147d6124d1565b602002602001015160400151611563565b8181815181106114a0576114a06124d1565b602002602001015160400151600360008484815181106114c2576114c26124d1565b60200260200101516000015163ffffffff1663ffffffff16815260200190815260200160002060008484815181106114fc576114fc6124d1565b60200260200101516020015161ffff1661ffff168152602001908152602001600020908161152a9190612805565b5060010161145f565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610a7491906128c4565b600281015161ffff81166003146109105781604051639a6d49cd60e01b81526004016108859190611f9b565b611597611c13565b60408051808201909152600080825260208201526000806115ce33604089013560608a01356115c960208c018c6120b6565b611899565b915091506000806115df8984611208565b909250905061160b6115f460208b018b6120b6565b8383611605368d90038d018d61294f565b8b6118ea565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611659908d018d6120b6565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b60007f00000000000000000000000000000000000000000000000000000000000000006116b78184612981565b61097791906129a3565b60006116d06020828486612442565b6116d9916129c8565b9392505050565b60006116f0602860208486612442565b6116f9916129e6565b60c01c9392505050565b60006109777f00000000000000000000000000000000000000000000000000000000000000006001600160401b0384166129a3565b600061176e6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001685856119f5565b509092915050565b60606117858260288186612442565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016117da9493929190612a16565b6040516020818303038152906040529050949350505050565b60006109777f000000000000000000000000000000000000000000000000000000000000000083612981565b805160609015158061186857848460405160200161185492919091825260c01b6001600160c01b031916602082015260280190565b60405160208183030381529060405261188f565b8484338560405160200161187f9493929190612a65565b6040516020818303038152906040525b9150935093915050565b6000806118a7858585610fa7565b90925090506118e16001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016873085611a59565b94509492505050565b6118f2611c13565b60006119018460000151611a98565b60208501519091501561191b5761191b8460200151611ac0565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff16815260200161196b8c610fe3565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b81526004016119a79291906126f0565b60806040518083038185885af11580156119c5573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906119ea9190612aa8565b979650505050505050565b6040516001600160a01b03838116602483015260448201839052611a5491859182169063a9059cbb906064015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050611ba2565b505050565b6040516001600160a01b038481166024830152838116604483015260648201839052611a929186918216906323b872dd90608401611a22565b50505050565b6000813414611abc576040516304fb820960e51b8152346004820152602401610885565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b20573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b44919061220c565b90506001600160a01b038116611b6d576040516329b99a9560e11b815260040160405180910390fd5b6109106001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085611a59565b600080602060008451602086016000885af180611bc5576040513d6000823e3d81fd5b50506000513d91508115611bdd578060011415611bea565b6001600160a01b0384163b155b15611a9257604051635274afe760e01b81526001600160a01b0385166004820152602401610885565b60405180606001604052806000801916815260200160006001600160401b03168152602001611c55604051806040016040528060008152602001600081525090565b905290565b600060e08284031215611c6c57600080fd5b50919050565b600060208284031215611c8457600080fd5b81356001600160401b03811115611c9a57600080fd5b610aa084828501611c5a565b60005b83811015611cc1578181015183820152602001611ca9565b50506000910152565b60008151808452611ce2816020860160208601611ca6565b601f01601f19169290920160200192915050565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b83811015611d715788870360bf19018552815180518852830151838801879052611d5e87890182611cca565b9750509382019390820190600101611d32565b50508751606088015250505060208501516080850152509050610aa0565b600060608284031215611c6c57600080fd5b60008083601f840112611db357600080fd5b5081356001600160401b03811115611dca57600080fd5b602083019150836020828501011115611de257600080fd5b9250929050565b6001600160a01b0381168114610f6e57600080fd5b600080600080600080600060e0888a031215611e1957600080fd5b611e238989611d8f565b96506060880135955060808801356001600160401b0380821115611e4657600080fd5b611e528b838c01611da1565b909750955060a08a01359150611e6782611de9565b90935060c08901359080821115611e7d57600080fd5b50611e8a8a828b01611da1565b989b979a50959850939692959293505050565b803563ffffffff81168114611eb157600080fd5b919050565b60008060408385031215611ec957600080fd5b611ed283611e9d565b946020939093013593505050565b8015158114610f6e57600080fd5b60008060408385031215611f0157600080fd5b82356001600160401b03811115611f1757600080fd5b611f2385828601611c5a565b9250506020830135611f3481611ee0565b809150509250929050565b815181526020808301519082015260408101610977565b803561ffff81168114611eb157600080fd5b60008060408385031215611f7b57600080fd5b611f8483611e9d565b9150611f9260208401611f56565b90509250929050565b6020815260006116d96020830184611cca565b600060208284031215611fc057600080fd5b81356116d981611de9565b60008060008060a08587031215611fe157600080fd5b611feb8686611d8f565b935060608501356001600160401b0381111561200657600080fd5b61201287828801611da1565b909450925050608085013561202681611de9565b939692955090935050565b60008083601f84011261204357600080fd5b5081356001600160401b0381111561205a57600080fd5b6020830191508360208260051b8501011115611de257600080fd5b6000806020838503121561208857600080fd5b82356001600160401b0381111561209e57600080fd5b6120aa85828601612031565b90969095509350505050565b6000602082840312156120c857600080fd5b6116d982611e9d565b600080600080606085870312156120e757600080fd5b6120f085611e9d565b93506120fe60208601611f56565b925060408501356001600160401b0381111561211957600080fd5b61212587828801611da1565b95989497509550505050565b6000806000838503608081121561214757600080fd5b84356001600160401b0381111561215d57600080fd5b61216987828801611c5a565b9450506040601f198201121561217e57600080fd5b50602084019150606084013561219381611de9565b809150509250925092565b600060c082019050835182526001600160401b03602085015116602083015260408401516121d9604084018280518252602090810151910152565b5082516080830152602083015160a08301526116d9565b60006060828403121561220257600080fd5b6116d98383611d8f565b60006020828403121561221e57600080fd5b81516116d981611de9565b60006020828403121561223b57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b600181811c9082168061226c57607f821691505b602082108103611c6c57634e487b7160e01b600052602260045260246000fd5b604051606081016001600160401b03811182821017156122ae576122ae612242565b60405290565b604080519081016001600160401b03811182821017156122ae576122ae612242565b604051601f8201601f191681016001600160401b03811182821017156122fe576122fe612242565b604052919050565b60006001600160401b0382111561231f5761231f612242565b50601f01601f191660200190565b60006001600160401b038084111561234757612347612242565b8360051b60206123588183016122d6565b86815291850191818101903684111561237057600080fd5b865b848110156124365780358681111561238a5760008081fd5b8801606036829003121561239e5760008081fd5b6123a661228c565b6123af82611e9d565b81526123bc868301611f56565b86820152604080830135898111156123d45760008081fd5b929092019136601f8401126123e95760008081fd5b82356123fc6123f782612306565b6122d6565b81815236898387010111156124115760008081fd5b818986018a830137600091810189019190915290820152845250918301918301612372565b50979650505050505050565b6000808585111561245257600080fd5b8386111561245f57600080fd5b5050820193919092039150565b6000845161247e818460208901611ca6565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610aa0602083018486612494565b634e487b7160e01b600052603260045260246000fd5b6000823561013e198336030181126124fe57600080fd5b9190910192915050565b6000808335601e1984360301811261251f57600080fd5b8301803591506001600160401b0382111561253957600080fd5b602001915036819003821315611de257600080fd5b6001600160401b0381168114610f6e57600080fd5b63ffffffff61257189611e9d565b168152602088013560208201526000604089013561258e8161254e565b6001600160401b03811660408401525087606083015260e060808301526125b960e083018789612494565b6001600160a01b03861660a084015282810360c08401526125db818587612494565b9a9950505050505050505050565b6000602082840312156125fb57600080fd5b81516001600160401b0381111561261157600080fd5b8201601f8101841361262257600080fd5b80516126306123f782612306565b81815285602083850101111561264557600080fd5b611403826020830160208601611ca6565b60006020828403121561266857600080fd5b81356116d98161254e565b60018060a01b038516815283602082015261ffff831660408201526080606082015260006126a46080830184611cca565b9695505050505050565b6040815260006126c16040830185611cca565b82810360208401526114038185611cca565b6000602082840312156126e557600080fd5b81516116d981611ee0565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261272660e0840182611cca565b90506060850151603f198483030160a08501526127438282611cca565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b60006040828403121561277b57600080fd5b6127836122b4565b9050815181526020820151602082015292915050565b6000604082840312156127ab57600080fd5b6116d98383612769565b601f821115611a54576000816000526020600020601f850160051c810160208610156127de5750805b601f850160051c820191505b818110156127fd578281556001016127ea565b505050505050565b81516001600160401b0381111561281e5761281e612242565b6128328161282c8454612258565b846127b5565b602080601f831160018114612867576000841561284f5750858301515b600019600386901b1c1916600185901b1785556127fd565b600085815260208120601f198616915b8281101561289657888601518255948401946001909101908401612877565b50858210156128b45787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b8381101561294157888303603f190185528151805163ffffffff1684528781015161ffff1688850152860151606087850181905261292d81860183611cca565b9689019694505050908601906001016128ed565b509098975050505050505050565b60006040828403121561296157600080fd5b6129696122b4565b82358152602083013560208201528091505092915050565b60008261299e57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761097757634e487b7160e01b600052601160045260246000fd5b8035602083101561097757600019602084900360031b1b1692915050565b6001600160c01b03198135818116916008851015612a0e5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c82015260008251612a5581602c850160208701611ca6565b91909101602c0195945050505050565b8481526001600160401b0360c01b8460c01b16602082015282602882015260008251612a98816048850160208701611ca6565b9190910160480195945050505050565b600060808284031215612aba57600080fd5b612ac261228c565b825181526020830151612ad48161254e565b6020820152612ae68460408501612769565b6040820152939250505056fea2646970667358221220a568c9db2fc2c7ad8e801ba2fa6427028f3af7cbb60ede1182bca739649792de64736f6c63430008160033",
+  "devdoc": {
+    "details": "MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.WARNING: ONLY 1 of these should exist for a given global mesh, unless you make a NON-default implementation of GM and needs to be done very carefully.WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out. IF the 'innerToken' applies something like a transfer fee, the default will NOT work... a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.",
+    "errors": {
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "approvalRequired()": {
+        "details": "In the case of default OFTAdapter, approval is required.In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.",
+        "returns": {
+          "_0": "The address of the adapted ERC-20 token."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "title": "MarketToken_Adapter Contract",
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/arbitrum-mainnet/MarketToken_Adapter_WETH_WETH.json
+++ b/deployments/arbitrum-mainnet/MarketToken_Adapter_WETH_WETH.json
@@ -1,0 +1,1695 @@
+{
+  "address": "0x0110424A21D5DF818f4a789E5d9d9141a4E29A3C",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x3af218977b2951f5e537dc83a680dd3b05dcb5a5e55142ac98fb7f764cbbaa7f",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x0110424A21D5DF818f4a789E5d9d9141a4E29A3C",
+    "transactionIndex": 12,
+    "gasUsed": "2507009",
+    "logsBloom": "0x00000000000040000000000000008000000000000800020000800000001000000000000010000000000000000000000000000002000000000000000000000000000000000000000000000000000000000001000000000000000080000000000000000000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x89c868a7c0f58842900b9b877f660da185969a510e78277bf04eea64f0a3903c",
+    "transactionHash": "0x3af218977b2951f5e537dc83a680dd3b05dcb5a5e55142ac98fb7f764cbbaa7f",
+    "logs": [
+      {
+        "transactionIndex": 12,
+        "blockNumber": 409377861,
+        "transactionHash": "0x3af218977b2951f5e537dc83a680dd3b05dcb5a5e55142ac98fb7f764cbbaa7f",
+        "address": "0x0110424A21D5DF818f4a789E5d9d9141a4E29A3C",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 0,
+        "blockHash": "0x89c868a7c0f58842900b9b877f660da185969a510e78277bf04eea64f0a3903c"
+      },
+      {
+        "transactionIndex": 12,
+        "blockNumber": 409377861,
+        "transactionHash": "0x3af218977b2951f5e537dc83a680dd3b05dcb5a5e55142ac98fb7f764cbbaa7f",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000000110424a21d5df818f4a789e5d9d9141a4e29a3c00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 1,
+        "blockHash": "0x89c868a7c0f58842900b9b877f660da185969a510e78277bf04eea64f0a3903c"
+      }
+    ],
+    "blockNumber": 409377861,
+    "cumulativeGasUsed": "3066357",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "0x450bb6774Dd8a756274E0ab4107953259d2ac541",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_token\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"details\":\"MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.WARNING: ONLY 1 of these should exist for a given global mesh, unless you make a NON-default implementation of GM and needs to be done very carefully.WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out. IF the 'innerToken' applies something like a transfer fee, the default will NOT work... a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\",\"errors\":{\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}}},\"kind\":\"dev\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"approvalRequired()\":{\"details\":\"In the case of default OFTAdapter, approval is required.In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.\",\"returns\":{\"_0\":\"The address of the adapted ERC-20 token.\"}},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"title\":\"MarketToken_Adapter Contract\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_Adapter.sol\":\"MarketToken_Adapter\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTAdapter.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20Metadata, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\\\";\\nimport { SafeERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFTAdapter Contract\\n * @dev OFTAdapter is a contract that adapts an ERC-20 token to the OFT functionality.\\n *\\n * @dev For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.\\n * @dev WARNING: ONLY 1 of these should exist for a given global mesh,\\n * unless you make a NON-default implementation of OFT and needs to be done very carefully.\\n * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n * a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\\n */\\nabstract contract OFTAdapter is OFTCore {\\n    using SafeERC20 for IERC20;\\n\\n    IERC20 internal immutable innerToken;\\n\\n    /**\\n     * @dev Constructor for the OFTAdapter contract.\\n     * @param _token The address of the ERC-20 token to be adapted.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        address _token,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFTCore(IERC20Metadata(_token).decimals(), _lzEndpoint, _delegate) {\\n        innerToken = IERC20(_token);\\n    }\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the adapted ERC-20 token.\\n     *\\n     * @dev In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(innerToken);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of default OFTAdapter, approval is required.\\n     * @dev In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Locks tokens from the sender's specified balance in this contract.\\n     * @param _from The address to debit from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev msg.sender will need to approve this _amountLD of tokens to be locked inside of the contract.\\n     * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n     * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n     * a pre/post balance check will need to be done to calculate the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n        // @dev Lock tokens by moving them into this contract from the caller.\\n        innerToken.safeTransferFrom(_from, address(this), amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     *\\n     * @dev WARNING: The default OFTAdapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n     * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n     * a pre/post balance check will need to be done to calculate the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        // @dev Unlock the tokens and transfer to the recipient.\\n        innerToken.safeTransfer(_to, _amountLD);\\n        // @dev In the case of NON-default OFTAdapter, the amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xd65041c093c19792b66369a04b4aea5c988c32e2cf4ab952a442315426407fd0\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_Adapter.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { OFTAdapter } from \\\"@layerzerolabs/oft-evm/contracts/OFTAdapter.sol\\\";\\n\\n/**\\n * @title MarketToken_Adapter Contract\\n * @dev MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.\\n *\\n * @dev For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.\\n * @dev WARNING: ONLY 1 of these should exist for a given global mesh,\\n * unless you make a NON-default implementation of GM and needs to be done very carefully.\\n * @dev WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out.\\n * IF the 'innerToken' applies something like a transfer fee, the default will NOT work...\\n * a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.\\n */\\ncontract MarketToken_Adapter is OFTAdapter {\\n    constructor(\\n        address _token,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFTAdapter(_token, _lzEndpoint, _delegate) Ownable(_delegate) {}\\n}\\n\",\"keccak256\":\"0xd6457a4a2e8e110dced051d22732dc78ab3d72822949f99a2b1a2d7cd0cca924\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x60e06040523480156200001157600080fd5b5060405162002fbc38038062002fbc833981016040819052620000349162000254565b828282826001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa15801562000076573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906200009c91906200029e565b8282818181818a6001600160a01b038116620000d257604051631e4fbdf760e01b81526000600482015260240160405180910390fd5b620000dd81620001e2565b506001600160a01b0380831660805281166200010c57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200015457600080fd5b505af115801562000169573d6000803e3d6000fd5b5050505050505050620001816200023260201b60201c565b60ff168360ff161015620001a8576040516301e9714b60e41b815260040160405180910390fd5b620001b5600684620002e0565b620001c290600a620003ff565b60a0525050506001600160a01b0390921660c05250620004109350505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b80516001600160a01b03811681146200024f57600080fd5b919050565b6000806000606084860312156200026a57600080fd5b620002758462000237565b9250620002856020850162000237565b9150620002956040850162000237565b90509250925092565b600060208284031215620002b157600080fd5b815160ff81168114620002c357600080fd5b9392505050565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620002fc57620002fc620002ca565b92915050565b600181815b8085111562000343578160001904821115620003275762000327620002ca565b808516156200033557918102915b93841c939080029062000307565b509250929050565b6000826200035c57506001620002fc565b816200036b57506000620002fc565b81600181146200038457600281146200038f57620003af565b6001915050620002fc565b60ff841115620003a357620003a3620002ca565b50506001821b620002fc565b5060208310610133831016604e8410600b8410161715620003d4575081810a620002fc565b620003e0838362000302565b8060001904821115620003f757620003f7620002ca565b029392505050565b6000620002c360ff8416836200034b565b60805160a05160c051612b2862000494600039600081816106690152818161174701526118b90152600081816104e20152818161168e0152818161170a01526117fa0152600081816103e40152818161084001528181610e4f015281816110b4015281816113410152818161191d01528181611ac40152611b7d0152612b286000f3fe6080604052600436106101ee5760003560e01c806382413eac1161010d578063bc70b354116100a0578063d045a0dc1161006f578063d045a0dc14610607578063d42438851461061a578063f2fde38b1461063a578063fc0c546a1461065a578063ff7bd03d1461068d57600080fd5b8063bc70b35414610593578063bd815db0146105b3578063c7c7f5b3146105c6578063ca5eb5e1146105e757600080fd5b80639f68b964116100dc5780639f68b96414610512578063b731ea0a14610526578063b98bd07014610546578063bb0b6a531461056657600080fd5b806382413eac14610476578063857749b0146104965780638da5cb5b146104b2578063963efcaa146104d057600080fd5b80633b6f743b116101855780635e280f11116101545780635e280f11146103d25780636fc1b31e14610406578063715018a6146104265780637d25a05e1461043b57600080fd5b80633b6f743b1461031e57806352ae28791461034b5780635535d4611461035e5780635a0dfe4d1461038b57600080fd5b8063156a0d0f116101c1578063156a0d0f146102a057806317442b70146102c75780631f5e1334146102e95780633400288b146102fe57600080fd5b80630d35b415146101f3578063111ecdad1461022b57806313137d6514610263578063134d4f2514610278575b600080fd5b3480156101ff57600080fd5b5061021361020e366004611c72565b6106ad565b60405161022293929190611cf6565b60405180910390f35b34801561023757600080fd5b5060045461024b906001600160a01b031681565b6040516001600160a01b039091168152602001610222565b610276610271366004611dfe565b61083e565b005b34801561028457600080fd5b5061028d600281565b60405161ffff9091168152602001610222565b3480156102ac57600080fd5b506040805162b9270b60e21b81526001602082015201610222565b3480156102d357600080fd5b5060408051600181526002602082015201610222565b3480156102f557600080fd5b5061028d600181565b34801561030a57600080fd5b50610276610319366004611eb6565b6108fe565b34801561032a57600080fd5b5061033e610339366004611eee565b610914565b6040516102229190611f3f565b34801561035757600080fd5b503061024b565b34801561036a57600080fd5b5061037e610379366004611f68565b61097d565b6040516102229190611f9b565b34801561039757600080fd5b506103c26103a6366004611eb6565b63ffffffff919091166000908152600160205260409020541490565b6040519015158152602001610222565b3480156103de57600080fd5b5061024b7f000000000000000000000000000000000000000000000000000000000000000081565b34801561041257600080fd5b50610276610421366004611fae565b610a22565b34801561043257600080fd5b50610276610a7f565b34801561044757600080fd5b5061045e610456366004611eb6565b600092915050565b6040516001600160401b039091168152602001610222565b34801561048257600080fd5b506103c2610491366004611fcb565b610a93565b3480156104a257600080fd5b5060405160068152602001610222565b3480156104be57600080fd5b506000546001600160a01b031661024b565b3480156104dc57600080fd5b506105047f000000000000000000000000000000000000000000000000000000000000000081565b604051908152602001610222565b34801561051e57600080fd5b5060016103c2565b34801561053257600080fd5b5060025461024b906001600160a01b031681565b34801561055257600080fd5b50610276610561366004612075565b610aa8565b34801561057257600080fd5b506105046105813660046120b6565b60016020526000908152604090205481565b34801561059f57600080fd5b5061037e6105ae3660046120d1565b610ac2565b6102766105c1366004612075565b610c6a565b6105d96105d4366004612131565b610df4565b60405161022292919061219e565b3480156105f357600080fd5b50610276610602366004611fae565b610e28565b610276610615366004611dfe565b610eae565b34801561062657600080fd5b50610276610635366004611fae565b610edd565b34801561064657600080fd5b50610276610655366004611fae565b610f33565b34801561066657600080fd5b507f000000000000000000000000000000000000000000000000000000000000000061024b565b34801561069957600080fd5b506103c26106a83660046121f0565b610f71565b604080518082019091526000808252602082015260606106e0604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610721573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610745919061220c565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610782573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107a69190612229565b604080518082018252848152602080820184905282516000808252918101909352909750919250906107fb565b6040805180820190915260008152606060208201528152602001906001900390816107d35790505b509350600080610820604089013560608a013561081b60208c018c6120b6565b610fa7565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316331461088e576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b602087018035906108a8906108a3908a6120b6565b610fe3565b146108e6576108ba60208801886120b6565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610885565b6108f58787878787878761101f565b50505050505050565b610906611186565b61091082826111b3565b5050565b604080518082019091526000808252602082015260006109446040850135606086013561081b60208801886120b6565b9150506000806109548684611208565b909250905061097161096960208801886120b6565b83838861132b565b93505050505b92915050565b6003602090815260009283526040808420909152908252902080546109a190612258565b80601f01602080910402602001604051908101604052809291908181526020018280546109cd90612258565b8015610a1a5780601f106109ef57610100808354040283529160200191610a1a565b820191906000526020600020905b8154815290600101906020018083116109fd57829003601f168201915b505050505081565b610a2a611186565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610a87611186565b610a91600061140c565b565b6001600160a01b03811630145b949350505050565b610ab0611186565b610910610abd828461232d565b61145c565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610af690612258565b80601f0160208091040260200160405190810160405280929190818152602001828054610b2290612258565b8015610b6f5780601f10610b4457610100808354040283529160200191610b6f565b820191906000526020600020905b815481529060010190602001808311610b5257829003601f168201915b505050505090508051600003610bbf5783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610aa09350505050565b6000839003610bcf579050610aa0565b60028310610c4d57610c1684848080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061156392505050565b80610c248460028188612442565b604051602001610c369392919061246c565b604051602081830303815290604052915050610aa0565b8383604051639a6d49cd60e01b81526004016108859291906124bd565b60005b81811015610d735736838383818110610c8857610c886124d1565b9050602002810190610c9a91906124e7565b9050610ccd610cac60208301836120b6565b602083013563ffffffff919091166000908152600160205260409020541490565b610cd75750610d6b565b3063d045a0dc60c08301358360a0810135610cf6610100830183612508565b610d07610100890160e08a01611fae565b610d156101208a018a612508565b6040518963ffffffff1660e01b8152600401610d379796959493929190612563565b6000604051808303818588803b158015610d5057600080fd5b505af1158015610d64573d6000803e3d6000fd5b5050505050505b600101610c6d565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa158015610db2573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052610dda91908101906125e9565b604051638351eea760e01b81526004016108859190611f9b565b610dfc611c13565b6040805180820190915260008082526020820152610e1b85858561158f565b915091505b935093915050565b610e30611186565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b158015610e9357600080fd5b505af1158015610ea7573d6000803e3d6000fd5b5050505050565b333014610ece5760405163029a949d60e31b815260040160405180910390fd5b6108f5878787878787876108e6565b610ee5611186565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610a74565b610f3b611186565b6001600160a01b038116610f6557604051631e4fbdf760e01b815260006004820152602401610885565b610f6e8161140c565b50565b6000602082018035906001908390610f8990866120b6565b63ffffffff1681526020810191909152604001600020541492915050565b600080610fb38561168a565b915081905083811015610e20576040516371c4efed60e01b81526004810182905260248101859052604401610885565b63ffffffff8116600090815260016020526040812054806109775760405163f6ff4fb760e01b815263ffffffff84166004820152602401610885565b600061103161102e87876116c1565b90565b9050600061105d8261104b6110468a8a6116e0565b611703565b61105860208d018d6120b6565b611738565b9050602886111561112457600061109a61107d60608c0160408d01612656565b61108a60208d018d6120b6565b846110958c8c611776565b6117c1565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906110f09086908d906000908790600401612673565b600060405180830381600087803b15801561110a57600080fd5b505af115801561111e573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61115d60208d018d6120b6565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6000546001600160a01b03163314610a915760405163118cdaa760e01b8152336004820152602401610885565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6060806000611265856020013561121e866117f3565b61122b60a0890189612508565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061181f92505050565b909350905060008161127857600161127b565b60025b905061129b61128d60208801886120b6565b826105ae60808a018a612508565b6004549093506001600160a01b031680156113215760405163043a78eb60e01b81526001600160a01b0382169063043a78eb906112de90889088906004016126ae565b602060405180830381865afa1580156112fb573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061131f91906126d3565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff16815260200161138e89610fe3565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b81526004016113c39291906126f0565b6040805180830381865afa1580156113df573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906114039190612799565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60005b81518110156115335761148e82828151811061147d5761147d6124d1565b602002602001015160400151611563565b8181815181106114a0576114a06124d1565b602002602001015160400151600360008484815181106114c2576114c26124d1565b60200260200101516000015163ffffffff1663ffffffff16815260200190815260200160002060008484815181106114fc576114fc6124d1565b60200260200101516020015161ffff1661ffff168152602001908152602001600020908161152a9190612805565b5060010161145f565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610a7491906128c4565b600281015161ffff81166003146109105781604051639a6d49cd60e01b81526004016108859190611f9b565b611597611c13565b60408051808201909152600080825260208201526000806115ce33604089013560608a01356115c960208c018c6120b6565b611899565b915091506000806115df8984611208565b909250905061160b6115f460208b018b6120b6565b8383611605368d90038d018d61294f565b8b6118ea565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611659908d018d6120b6565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b60007f00000000000000000000000000000000000000000000000000000000000000006116b78184612981565b61097791906129a3565b60006116d06020828486612442565b6116d9916129c8565b9392505050565b60006116f0602860208486612442565b6116f9916129e6565b60c01c9392505050565b60006109777f00000000000000000000000000000000000000000000000000000000000000006001600160401b0384166129a3565b600061176e6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001685856119f5565b509092915050565b60606117858260288186612442565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016117da9493929190612a16565b6040516020818303038152906040529050949350505050565b60006109777f000000000000000000000000000000000000000000000000000000000000000083612981565b805160609015158061186857848460405160200161185492919091825260c01b6001600160c01b031916602082015260280190565b60405160208183030381529060405261188f565b8484338560405160200161187f9493929190612a65565b6040516020818303038152906040525b9150935093915050565b6000806118a7858585610fa7565b90925090506118e16001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016873085611a59565b94509492505050565b6118f2611c13565b60006119018460000151611a98565b60208501519091501561191b5761191b8460200151611ac0565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff16815260200161196b8c610fe3565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b81526004016119a79291906126f0565b60806040518083038185885af11580156119c5573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906119ea9190612aa8565b979650505050505050565b6040516001600160a01b03838116602483015260448201839052611a5491859182169063a9059cbb906064015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050611ba2565b505050565b6040516001600160a01b038481166024830152838116604483015260648201839052611a929186918216906323b872dd90608401611a22565b50505050565b6000813414611abc576040516304fb820960e51b8152346004820152602401610885565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b20573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b44919061220c565b90506001600160a01b038116611b6d576040516329b99a9560e11b815260040160405180910390fd5b6109106001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085611a59565b600080602060008451602086016000885af180611bc5576040513d6000823e3d81fd5b50506000513d91508115611bdd578060011415611bea565b6001600160a01b0384163b155b15611a9257604051635274afe760e01b81526001600160a01b0385166004820152602401610885565b60405180606001604052806000801916815260200160006001600160401b03168152602001611c55604051806040016040528060008152602001600081525090565b905290565b600060e08284031215611c6c57600080fd5b50919050565b600060208284031215611c8457600080fd5b81356001600160401b03811115611c9a57600080fd5b610aa084828501611c5a565b60005b83811015611cc1578181015183820152602001611ca9565b50506000910152565b60008151808452611ce2816020860160208601611ca6565b601f01601f19169290920160200192915050565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b83811015611d715788870360bf19018552815180518852830151838801879052611d5e87890182611cca565b9750509382019390820190600101611d32565b50508751606088015250505060208501516080850152509050610aa0565b600060608284031215611c6c57600080fd5b60008083601f840112611db357600080fd5b5081356001600160401b03811115611dca57600080fd5b602083019150836020828501011115611de257600080fd5b9250929050565b6001600160a01b0381168114610f6e57600080fd5b600080600080600080600060e0888a031215611e1957600080fd5b611e238989611d8f565b96506060880135955060808801356001600160401b0380821115611e4657600080fd5b611e528b838c01611da1565b909750955060a08a01359150611e6782611de9565b90935060c08901359080821115611e7d57600080fd5b50611e8a8a828b01611da1565b989b979a50959850939692959293505050565b803563ffffffff81168114611eb157600080fd5b919050565b60008060408385031215611ec957600080fd5b611ed283611e9d565b946020939093013593505050565b8015158114610f6e57600080fd5b60008060408385031215611f0157600080fd5b82356001600160401b03811115611f1757600080fd5b611f2385828601611c5a565b9250506020830135611f3481611ee0565b809150509250929050565b815181526020808301519082015260408101610977565b803561ffff81168114611eb157600080fd5b60008060408385031215611f7b57600080fd5b611f8483611e9d565b9150611f9260208401611f56565b90509250929050565b6020815260006116d96020830184611cca565b600060208284031215611fc057600080fd5b81356116d981611de9565b60008060008060a08587031215611fe157600080fd5b611feb8686611d8f565b935060608501356001600160401b0381111561200657600080fd5b61201287828801611da1565b909450925050608085013561202681611de9565b939692955090935050565b60008083601f84011261204357600080fd5b5081356001600160401b0381111561205a57600080fd5b6020830191508360208260051b8501011115611de257600080fd5b6000806020838503121561208857600080fd5b82356001600160401b0381111561209e57600080fd5b6120aa85828601612031565b90969095509350505050565b6000602082840312156120c857600080fd5b6116d982611e9d565b600080600080606085870312156120e757600080fd5b6120f085611e9d565b93506120fe60208601611f56565b925060408501356001600160401b0381111561211957600080fd5b61212587828801611da1565b95989497509550505050565b6000806000838503608081121561214757600080fd5b84356001600160401b0381111561215d57600080fd5b61216987828801611c5a565b9450506040601f198201121561217e57600080fd5b50602084019150606084013561219381611de9565b809150509250925092565b600060c082019050835182526001600160401b03602085015116602083015260408401516121d9604084018280518252602090810151910152565b5082516080830152602083015160a08301526116d9565b60006060828403121561220257600080fd5b6116d98383611d8f565b60006020828403121561221e57600080fd5b81516116d981611de9565b60006020828403121561223b57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b600181811c9082168061226c57607f821691505b602082108103611c6c57634e487b7160e01b600052602260045260246000fd5b604051606081016001600160401b03811182821017156122ae576122ae612242565b60405290565b604080519081016001600160401b03811182821017156122ae576122ae612242565b604051601f8201601f191681016001600160401b03811182821017156122fe576122fe612242565b604052919050565b60006001600160401b0382111561231f5761231f612242565b50601f01601f191660200190565b60006001600160401b038084111561234757612347612242565b8360051b60206123588183016122d6565b86815291850191818101903684111561237057600080fd5b865b848110156124365780358681111561238a5760008081fd5b8801606036829003121561239e5760008081fd5b6123a661228c565b6123af82611e9d565b81526123bc868301611f56565b86820152604080830135898111156123d45760008081fd5b929092019136601f8401126123e95760008081fd5b82356123fc6123f782612306565b6122d6565b81815236898387010111156124115760008081fd5b818986018a830137600091810189019190915290820152845250918301918301612372565b50979650505050505050565b6000808585111561245257600080fd5b8386111561245f57600080fd5b5050820193919092039150565b6000845161247e818460208901611ca6565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610aa0602083018486612494565b634e487b7160e01b600052603260045260246000fd5b6000823561013e198336030181126124fe57600080fd5b9190910192915050565b6000808335601e1984360301811261251f57600080fd5b8301803591506001600160401b0382111561253957600080fd5b602001915036819003821315611de257600080fd5b6001600160401b0381168114610f6e57600080fd5b63ffffffff61257189611e9d565b168152602088013560208201526000604089013561258e8161254e565b6001600160401b03811660408401525087606083015260e060808301526125b960e083018789612494565b6001600160a01b03861660a084015282810360c08401526125db818587612494565b9a9950505050505050505050565b6000602082840312156125fb57600080fd5b81516001600160401b0381111561261157600080fd5b8201601f8101841361262257600080fd5b80516126306123f782612306565b81815285602083850101111561264557600080fd5b611403826020830160208601611ca6565b60006020828403121561266857600080fd5b81356116d98161254e565b60018060a01b038516815283602082015261ffff831660408201526080606082015260006126a46080830184611cca565b9695505050505050565b6040815260006126c16040830185611cca565b82810360208401526114038185611cca565b6000602082840312156126e557600080fd5b81516116d981611ee0565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261272660e0840182611cca565b90506060850151603f198483030160a08501526127438282611cca565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b60006040828403121561277b57600080fd5b6127836122b4565b9050815181526020820151602082015292915050565b6000604082840312156127ab57600080fd5b6116d98383612769565b601f821115611a54576000816000526020600020601f850160051c810160208610156127de5750805b601f850160051c820191505b818110156127fd578281556001016127ea565b505050505050565b81516001600160401b0381111561281e5761281e612242565b6128328161282c8454612258565b846127b5565b602080601f831160018114612867576000841561284f5750858301515b600019600386901b1c1916600185901b1785556127fd565b600085815260208120601f198616915b8281101561289657888601518255948401946001909101908401612877565b50858210156128b45787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b8381101561294157888303603f190185528151805163ffffffff1684528781015161ffff1688850152860151606087850181905261292d81860183611cca565b9689019694505050908601906001016128ed565b509098975050505050505050565b60006040828403121561296157600080fd5b6129696122b4565b82358152602083013560208201528091505092915050565b60008261299e57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761097757634e487b7160e01b600052601160045260246000fd5b8035602083101561097757600019602084900360031b1b1692915050565b6001600160c01b03198135818116916008851015612a0e5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c82015260008251612a5581602c850160208701611ca6565b91909101602c0195945050505050565b8481526001600160401b0360c01b8460c01b16602082015282602882015260008251612a98816048850160208701611ca6565b9190910160480195945050505050565b600060808284031215612aba57600080fd5b612ac261228c565b825181526020830151612ad48161254e565b6020820152612ae68460408501612769565b6040820152939250505056fea2646970667358221220a568c9db2fc2c7ad8e801ba2fa6427028f3af7cbb60ede1182bca739649792de64736f6c63430008160033",
+  "deployedBytecode": "0x6080604052600436106101ee5760003560e01c806382413eac1161010d578063bc70b354116100a0578063d045a0dc1161006f578063d045a0dc14610607578063d42438851461061a578063f2fde38b1461063a578063fc0c546a1461065a578063ff7bd03d1461068d57600080fd5b8063bc70b35414610593578063bd815db0146105b3578063c7c7f5b3146105c6578063ca5eb5e1146105e757600080fd5b80639f68b964116100dc5780639f68b96414610512578063b731ea0a14610526578063b98bd07014610546578063bb0b6a531461056657600080fd5b806382413eac14610476578063857749b0146104965780638da5cb5b146104b2578063963efcaa146104d057600080fd5b80633b6f743b116101855780635e280f11116101545780635e280f11146103d25780636fc1b31e14610406578063715018a6146104265780637d25a05e1461043b57600080fd5b80633b6f743b1461031e57806352ae28791461034b5780635535d4611461035e5780635a0dfe4d1461038b57600080fd5b8063156a0d0f116101c1578063156a0d0f146102a057806317442b70146102c75780631f5e1334146102e95780633400288b146102fe57600080fd5b80630d35b415146101f3578063111ecdad1461022b57806313137d6514610263578063134d4f2514610278575b600080fd5b3480156101ff57600080fd5b5061021361020e366004611c72565b6106ad565b60405161022293929190611cf6565b60405180910390f35b34801561023757600080fd5b5060045461024b906001600160a01b031681565b6040516001600160a01b039091168152602001610222565b610276610271366004611dfe565b61083e565b005b34801561028457600080fd5b5061028d600281565b60405161ffff9091168152602001610222565b3480156102ac57600080fd5b506040805162b9270b60e21b81526001602082015201610222565b3480156102d357600080fd5b5060408051600181526002602082015201610222565b3480156102f557600080fd5b5061028d600181565b34801561030a57600080fd5b50610276610319366004611eb6565b6108fe565b34801561032a57600080fd5b5061033e610339366004611eee565b610914565b6040516102229190611f3f565b34801561035757600080fd5b503061024b565b34801561036a57600080fd5b5061037e610379366004611f68565b61097d565b6040516102229190611f9b565b34801561039757600080fd5b506103c26103a6366004611eb6565b63ffffffff919091166000908152600160205260409020541490565b6040519015158152602001610222565b3480156103de57600080fd5b5061024b7f000000000000000000000000000000000000000000000000000000000000000081565b34801561041257600080fd5b50610276610421366004611fae565b610a22565b34801561043257600080fd5b50610276610a7f565b34801561044757600080fd5b5061045e610456366004611eb6565b600092915050565b6040516001600160401b039091168152602001610222565b34801561048257600080fd5b506103c2610491366004611fcb565b610a93565b3480156104a257600080fd5b5060405160068152602001610222565b3480156104be57600080fd5b506000546001600160a01b031661024b565b3480156104dc57600080fd5b506105047f000000000000000000000000000000000000000000000000000000000000000081565b604051908152602001610222565b34801561051e57600080fd5b5060016103c2565b34801561053257600080fd5b5060025461024b906001600160a01b031681565b34801561055257600080fd5b50610276610561366004612075565b610aa8565b34801561057257600080fd5b506105046105813660046120b6565b60016020526000908152604090205481565b34801561059f57600080fd5b5061037e6105ae3660046120d1565b610ac2565b6102766105c1366004612075565b610c6a565b6105d96105d4366004612131565b610df4565b60405161022292919061219e565b3480156105f357600080fd5b50610276610602366004611fae565b610e28565b610276610615366004611dfe565b610eae565b34801561062657600080fd5b50610276610635366004611fae565b610edd565b34801561064657600080fd5b50610276610655366004611fae565b610f33565b34801561066657600080fd5b507f000000000000000000000000000000000000000000000000000000000000000061024b565b34801561069957600080fd5b506103c26106a83660046121f0565b610f71565b604080518082019091526000808252602082015260606106e0604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610721573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610745919061220c565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610782573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107a69190612229565b604080518082018252848152602080820184905282516000808252918101909352909750919250906107fb565b6040805180820190915260008152606060208201528152602001906001900390816107d35790505b509350600080610820604089013560608a013561081b60208c018c6120b6565b610fa7565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316331461088e576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b602087018035906108a8906108a3908a6120b6565b610fe3565b146108e6576108ba60208801886120b6565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610885565b6108f58787878787878761101f565b50505050505050565b610906611186565b61091082826111b3565b5050565b604080518082019091526000808252602082015260006109446040850135606086013561081b60208801886120b6565b9150506000806109548684611208565b909250905061097161096960208801886120b6565b83838861132b565b93505050505b92915050565b6003602090815260009283526040808420909152908252902080546109a190612258565b80601f01602080910402602001604051908101604052809291908181526020018280546109cd90612258565b8015610a1a5780601f106109ef57610100808354040283529160200191610a1a565b820191906000526020600020905b8154815290600101906020018083116109fd57829003601f168201915b505050505081565b610a2a611186565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610a87611186565b610a91600061140c565b565b6001600160a01b03811630145b949350505050565b610ab0611186565b610910610abd828461232d565b61145c565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610af690612258565b80601f0160208091040260200160405190810160405280929190818152602001828054610b2290612258565b8015610b6f5780601f10610b4457610100808354040283529160200191610b6f565b820191906000526020600020905b815481529060010190602001808311610b5257829003601f168201915b505050505090508051600003610bbf5783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610aa09350505050565b6000839003610bcf579050610aa0565b60028310610c4d57610c1684848080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061156392505050565b80610c248460028188612442565b604051602001610c369392919061246c565b604051602081830303815290604052915050610aa0565b8383604051639a6d49cd60e01b81526004016108859291906124bd565b60005b81811015610d735736838383818110610c8857610c886124d1565b9050602002810190610c9a91906124e7565b9050610ccd610cac60208301836120b6565b602083013563ffffffff919091166000908152600160205260409020541490565b610cd75750610d6b565b3063d045a0dc60c08301358360a0810135610cf6610100830183612508565b610d07610100890160e08a01611fae565b610d156101208a018a612508565b6040518963ffffffff1660e01b8152600401610d379796959493929190612563565b6000604051808303818588803b158015610d5057600080fd5b505af1158015610d64573d6000803e3d6000fd5b5050505050505b600101610c6d565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa158015610db2573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f19168201604052610dda91908101906125e9565b604051638351eea760e01b81526004016108859190611f9b565b610dfc611c13565b6040805180820190915260008082526020820152610e1b85858561158f565b915091505b935093915050565b610e30611186565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b158015610e9357600080fd5b505af1158015610ea7573d6000803e3d6000fd5b5050505050565b333014610ece5760405163029a949d60e31b815260040160405180910390fd5b6108f5878787878787876108e6565b610ee5611186565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610a74565b610f3b611186565b6001600160a01b038116610f6557604051631e4fbdf760e01b815260006004820152602401610885565b610f6e8161140c565b50565b6000602082018035906001908390610f8990866120b6565b63ffffffff1681526020810191909152604001600020541492915050565b600080610fb38561168a565b915081905083811015610e20576040516371c4efed60e01b81526004810182905260248101859052604401610885565b63ffffffff8116600090815260016020526040812054806109775760405163f6ff4fb760e01b815263ffffffff84166004820152602401610885565b600061103161102e87876116c1565b90565b9050600061105d8261104b6110468a8a6116e0565b611703565b61105860208d018d6120b6565b611738565b9050602886111561112457600061109a61107d60608c0160408d01612656565b61108a60208d018d6120b6565b846110958c8c611776565b6117c1565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906110f09086908d906000908790600401612673565b600060405180830381600087803b15801561110a57600080fd5b505af115801561111e573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61115d60208d018d6120b6565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6000546001600160a01b03163314610a915760405163118cdaa760e01b8152336004820152602401610885565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6060806000611265856020013561121e866117f3565b61122b60a0890189612508565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061181f92505050565b909350905060008161127857600161127b565b60025b905061129b61128d60208801886120b6565b826105ae60808a018a612508565b6004549093506001600160a01b031680156113215760405163043a78eb60e01b81526001600160a01b0382169063043a78eb906112de90889088906004016126ae565b602060405180830381865afa1580156112fb573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061131f91906126d3565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff16815260200161138e89610fe3565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b81526004016113c39291906126f0565b6040805180830381865afa1580156113df573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906114039190612799565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b60005b81518110156115335761148e82828151811061147d5761147d6124d1565b602002602001015160400151611563565b8181815181106114a0576114a06124d1565b602002602001015160400151600360008484815181106114c2576114c26124d1565b60200260200101516000015163ffffffff1663ffffffff16815260200190815260200160002060008484815181106114fc576114fc6124d1565b60200260200101516020015161ffff1661ffff168152602001908152602001600020908161152a9190612805565b5060010161145f565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610a7491906128c4565b600281015161ffff81166003146109105781604051639a6d49cd60e01b81526004016108859190611f9b565b611597611c13565b60408051808201909152600080825260208201526000806115ce33604089013560608a01356115c960208c018c6120b6565b611899565b915091506000806115df8984611208565b909250905061160b6115f460208b018b6120b6565b8383611605368d90038d018d61294f565b8b6118ea565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611659908d018d6120b6565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b60007f00000000000000000000000000000000000000000000000000000000000000006116b78184612981565b61097791906129a3565b60006116d06020828486612442565b6116d9916129c8565b9392505050565b60006116f0602860208486612442565b6116f9916129e6565b60c01c9392505050565b60006109777f00000000000000000000000000000000000000000000000000000000000000006001600160401b0384166129a3565b600061176e6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001685856119f5565b509092915050565b60606117858260288186612442565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016117da9493929190612a16565b6040516020818303038152906040529050949350505050565b60006109777f000000000000000000000000000000000000000000000000000000000000000083612981565b805160609015158061186857848460405160200161185492919091825260c01b6001600160c01b031916602082015260280190565b60405160208183030381529060405261188f565b8484338560405160200161187f9493929190612a65565b6040516020818303038152906040525b9150935093915050565b6000806118a7858585610fa7565b90925090506118e16001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016873085611a59565b94509492505050565b6118f2611c13565b60006119018460000151611a98565b60208501519091501561191b5761191b8460200151611ac0565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff16815260200161196b8c610fe3565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b81526004016119a79291906126f0565b60806040518083038185885af11580156119c5573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906119ea9190612aa8565b979650505050505050565b6040516001600160a01b03838116602483015260448201839052611a5491859182169063a9059cbb906064015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050611ba2565b505050565b6040516001600160a01b038481166024830152838116604483015260648201839052611a929186918216906323b872dd90608401611a22565b50505050565b6000813414611abc576040516304fb820960e51b8152346004820152602401610885565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b20573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b44919061220c565b90506001600160a01b038116611b6d576040516329b99a9560e11b815260040160405180910390fd5b6109106001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085611a59565b600080602060008451602086016000885af180611bc5576040513d6000823e3d81fd5b50506000513d91508115611bdd578060011415611bea565b6001600160a01b0384163b155b15611a9257604051635274afe760e01b81526001600160a01b0385166004820152602401610885565b60405180606001604052806000801916815260200160006001600160401b03168152602001611c55604051806040016040528060008152602001600081525090565b905290565b600060e08284031215611c6c57600080fd5b50919050565b600060208284031215611c8457600080fd5b81356001600160401b03811115611c9a57600080fd5b610aa084828501611c5a565b60005b83811015611cc1578181015183820152602001611ca9565b50506000910152565b60008151808452611ce2816020860160208601611ca6565b601f01601f19169290920160200192915050565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b83811015611d715788870360bf19018552815180518852830151838801879052611d5e87890182611cca565b9750509382019390820190600101611d32565b50508751606088015250505060208501516080850152509050610aa0565b600060608284031215611c6c57600080fd5b60008083601f840112611db357600080fd5b5081356001600160401b03811115611dca57600080fd5b602083019150836020828501011115611de257600080fd5b9250929050565b6001600160a01b0381168114610f6e57600080fd5b600080600080600080600060e0888a031215611e1957600080fd5b611e238989611d8f565b96506060880135955060808801356001600160401b0380821115611e4657600080fd5b611e528b838c01611da1565b909750955060a08a01359150611e6782611de9565b90935060c08901359080821115611e7d57600080fd5b50611e8a8a828b01611da1565b989b979a50959850939692959293505050565b803563ffffffff81168114611eb157600080fd5b919050565b60008060408385031215611ec957600080fd5b611ed283611e9d565b946020939093013593505050565b8015158114610f6e57600080fd5b60008060408385031215611f0157600080fd5b82356001600160401b03811115611f1757600080fd5b611f2385828601611c5a565b9250506020830135611f3481611ee0565b809150509250929050565b815181526020808301519082015260408101610977565b803561ffff81168114611eb157600080fd5b60008060408385031215611f7b57600080fd5b611f8483611e9d565b9150611f9260208401611f56565b90509250929050565b6020815260006116d96020830184611cca565b600060208284031215611fc057600080fd5b81356116d981611de9565b60008060008060a08587031215611fe157600080fd5b611feb8686611d8f565b935060608501356001600160401b0381111561200657600080fd5b61201287828801611da1565b909450925050608085013561202681611de9565b939692955090935050565b60008083601f84011261204357600080fd5b5081356001600160401b0381111561205a57600080fd5b6020830191508360208260051b8501011115611de257600080fd5b6000806020838503121561208857600080fd5b82356001600160401b0381111561209e57600080fd5b6120aa85828601612031565b90969095509350505050565b6000602082840312156120c857600080fd5b6116d982611e9d565b600080600080606085870312156120e757600080fd5b6120f085611e9d565b93506120fe60208601611f56565b925060408501356001600160401b0381111561211957600080fd5b61212587828801611da1565b95989497509550505050565b6000806000838503608081121561214757600080fd5b84356001600160401b0381111561215d57600080fd5b61216987828801611c5a565b9450506040601f198201121561217e57600080fd5b50602084019150606084013561219381611de9565b809150509250925092565b600060c082019050835182526001600160401b03602085015116602083015260408401516121d9604084018280518252602090810151910152565b5082516080830152602083015160a08301526116d9565b60006060828403121561220257600080fd5b6116d98383611d8f565b60006020828403121561221e57600080fd5b81516116d981611de9565b60006020828403121561223b57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b600181811c9082168061226c57607f821691505b602082108103611c6c57634e487b7160e01b600052602260045260246000fd5b604051606081016001600160401b03811182821017156122ae576122ae612242565b60405290565b604080519081016001600160401b03811182821017156122ae576122ae612242565b604051601f8201601f191681016001600160401b03811182821017156122fe576122fe612242565b604052919050565b60006001600160401b0382111561231f5761231f612242565b50601f01601f191660200190565b60006001600160401b038084111561234757612347612242565b8360051b60206123588183016122d6565b86815291850191818101903684111561237057600080fd5b865b848110156124365780358681111561238a5760008081fd5b8801606036829003121561239e5760008081fd5b6123a661228c565b6123af82611e9d565b81526123bc868301611f56565b86820152604080830135898111156123d45760008081fd5b929092019136601f8401126123e95760008081fd5b82356123fc6123f782612306565b6122d6565b81815236898387010111156124115760008081fd5b818986018a830137600091810189019190915290820152845250918301918301612372565b50979650505050505050565b6000808585111561245257600080fd5b8386111561245f57600080fd5b5050820193919092039150565b6000845161247e818460208901611ca6565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610aa0602083018486612494565b634e487b7160e01b600052603260045260246000fd5b6000823561013e198336030181126124fe57600080fd5b9190910192915050565b6000808335601e1984360301811261251f57600080fd5b8301803591506001600160401b0382111561253957600080fd5b602001915036819003821315611de257600080fd5b6001600160401b0381168114610f6e57600080fd5b63ffffffff61257189611e9d565b168152602088013560208201526000604089013561258e8161254e565b6001600160401b03811660408401525087606083015260e060808301526125b960e083018789612494565b6001600160a01b03861660a084015282810360c08401526125db818587612494565b9a9950505050505050505050565b6000602082840312156125fb57600080fd5b81516001600160401b0381111561261157600080fd5b8201601f8101841361262257600080fd5b80516126306123f782612306565b81815285602083850101111561264557600080fd5b611403826020830160208601611ca6565b60006020828403121561266857600080fd5b81356116d98161254e565b60018060a01b038516815283602082015261ffff831660408201526080606082015260006126a46080830184611cca565b9695505050505050565b6040815260006126c16040830185611cca565b82810360208401526114038185611cca565b6000602082840312156126e557600080fd5b81516116d981611ee0565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261272660e0840182611cca565b90506060850151603f198483030160a08501526127438282611cca565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b60006040828403121561277b57600080fd5b6127836122b4565b9050815181526020820151602082015292915050565b6000604082840312156127ab57600080fd5b6116d98383612769565b601f821115611a54576000816000526020600020601f850160051c810160208610156127de5750805b601f850160051c820191505b818110156127fd578281556001016127ea565b505050505050565b81516001600160401b0381111561281e5761281e612242565b6128328161282c8454612258565b846127b5565b602080601f831160018114612867576000841561284f5750858301515b600019600386901b1c1916600185901b1785556127fd565b600085815260208120601f198616915b8281101561289657888601518255948401946001909101908401612877565b50858210156128b45787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b8381101561294157888303603f190185528151805163ffffffff1684528781015161ffff1688850152860151606087850181905261292d81860183611cca565b9689019694505050908601906001016128ed565b509098975050505050505050565b60006040828403121561296157600080fd5b6129696122b4565b82358152602083013560208201528091505092915050565b60008261299e57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761097757634e487b7160e01b600052601160045260246000fd5b8035602083101561097757600019602084900360031b1b1692915050565b6001600160c01b03198135818116916008851015612a0e5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c82015260008251612a5581602c850160208701611ca6565b91909101602c0195945050505050565b8481526001600160401b0360c01b8460c01b16602082015282602882015260008251612a98816048850160208701611ca6565b9190910160480195945050505050565b600060808284031215612aba57600080fd5b612ac261228c565b825181526020830151612ad48161254e565b6020820152612ae68460408501612769565b6040820152939250505056fea2646970667358221220a568c9db2fc2c7ad8e801ba2fa6427028f3af7cbb60ede1182bca739649792de64736f6c63430008160033",
+  "devdoc": {
+    "details": "MarketToken_Adapter is a contract that adapts an ERC-20 token to the GM functionality.For existing ERC20 tokens, this can be used to convert the token to crosschain compatibility.WARNING: ONLY 1 of these should exist for a given global mesh, unless you make a NON-default implementation of GM and needs to be done very carefully.WARNING: The default MarketToken_Adapter implementation assumes LOSSLESS transfers, ie. 1 token in, 1 token out. IF the 'innerToken' applies something like a transfer fee, the default will NOT work... a pre/post balance check will need to be done to calculate the amountSentLD/amountReceivedLD.",
+    "errors": {
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "approvalRequired()": {
+        "details": "In the case of default OFTAdapter, approval is required.In non-default OFTAdapter contracts with something like mint and burn privileges, it would NOT need approval.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFTAdapter, address(this) and erc20 are NOT the same contract.",
+        "returns": {
+          "_0": "The address of the adapted ERC-20 token."
+        }
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "title": "MarketToken_Adapter Contract",
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_Adapter.sol:MarketToken_Adapter",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/base-mainnet/MarketToken_OFT_BTC_BTC.json
+++ b/deployments/base-mainnet/MarketToken_OFT_BTC_BTC.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x5E922D32c7278f6c5621a016c03055c54C97D27b",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xe1367ccf1117e594d9a0ca5f808eb970e69776d48acf486023486acd88bbe7cc",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x5E922D32c7278f6c5621a016c03055c54C97D27b",
+    "transactionIndex": 155,
+    "gasUsed": "3320174",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000001000000000000000000000000000000000000000000002000400000000000000000000000000000000000000000000000000000001000000000000000080000000000000000000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000400000000000000000000000020000000400000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x52a78408ddc3fa60ceb502aa4e71ad41a490e5800244b4aed4117426d962a441",
+    "transactionHash": "0xe1367ccf1117e594d9a0ca5f808eb970e69776d48acf486023486acd88bbe7cc",
+    "logs": [
+      {
+        "transactionIndex": 155,
+        "blockNumber": 39317215,
+        "transactionHash": "0xe1367ccf1117e594d9a0ca5f808eb970e69776d48acf486023486acd88bbe7cc",
+        "address": "0x5E922D32c7278f6c5621a016c03055c54C97D27b",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 515,
+        "blockHash": "0x52a78408ddc3fa60ceb502aa4e71ad41a490e5800244b4aed4117426d962a441"
+      },
+      {
+        "transactionIndex": 155,
+        "blockNumber": 39317215,
+        "transactionHash": "0xe1367ccf1117e594d9a0ca5f808eb970e69776d48acf486023486acd88bbe7cc",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000005e922d32c7278f6c5621a016c03055c54c97d27b00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 516,
+        "blockHash": "0x52a78408ddc3fa60ceb502aa4e71ad41a490e5800244b4aed4117426d962a441"
+      }
+    ],
+    "blockNumber": 39317215,
+    "cumulativeGasUsed": "32896084",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: BTC/USD [BTC-BTC]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/base-mainnet/MarketToken_OFT_WETH_WETH.json
+++ b/deployments/base-mainnet/MarketToken_OFT_WETH_WETH.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x47dFf0cbE239c02479C5944b9F4F3Ade8a212457",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xb2a866d67e2081467966f2da7b1149c8ee830b512f4c733af6800a6ae2a55b87",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x47dFf0cbE239c02479C5944b9F4F3Ade8a212457",
+    "transactionIndex": 218,
+    "gasUsed": "3320198",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000001000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000080001000000000000000080000000000000000000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000004000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0xd1b94952fa024417588c34012c65e0416afe22b038c35c2535da0daddf914701",
+    "transactionHash": "0xb2a866d67e2081467966f2da7b1149c8ee830b512f4c733af6800a6ae2a55b87",
+    "logs": [
+      {
+        "transactionIndex": 218,
+        "blockNumber": 39317080,
+        "transactionHash": "0xb2a866d67e2081467966f2da7b1149c8ee830b512f4c733af6800a6ae2a55b87",
+        "address": "0x47dFf0cbE239c02479C5944b9F4F3Ade8a212457",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 712,
+        "blockHash": "0xd1b94952fa024417588c34012c65e0416afe22b038c35c2535da0daddf914701"
+      },
+      {
+        "transactionIndex": 218,
+        "blockNumber": 39317080,
+        "transactionHash": "0xb2a866d67e2081467966f2da7b1149c8ee830b512f4c733af6800a6ae2a55b87",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x00000000000000000000000047dff0cbe239c02479c5944b9f4f3ade8a21245700000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 713,
+        "blockHash": "0xd1b94952fa024417588c34012c65e0416afe22b038c35c2535da0daddf914701"
+      }
+    ],
+    "blockNumber": 39317080,
+    "cumulativeGasUsed": "45181143",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: ETH/USD [WETH-WETH]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/bera-mainnet/MarketToken_OFT_BTC_BTC.json
+++ b/deployments/bera-mainnet/MarketToken_OFT_BTC_BTC.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0xa2d2e356c64dE9b0a5b4CFDfF2B4c82C0eC3D7A2",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x60bf258d211961057eb3d5029f7dbb553940764c58ca6c359016c0d64a6b4f11",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0xa2d2e356c64dE9b0a5b4CFDfF2B4c82C0eC3D7A2",
+    "transactionIndex": 3,
+    "gasUsed": "3320174",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000141000000000000000080000000000000000000020000000000000000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000400000000000000000000000000000000000000000000000000000000000020004000000000000000000000002000000000000000000000000000000000000000",
+    "blockHash": "0xab5a33b7d60e0fcc67e3a5566f8ba5218f8444409837bd80f2c0850af549cb29",
+    "transactionHash": "0x60bf258d211961057eb3d5029f7dbb553940764c58ca6c359016c0d64a6b4f11",
+    "logs": [
+      {
+        "transactionIndex": 3,
+        "blockNumber": 14204531,
+        "transactionHash": "0x60bf258d211961057eb3d5029f7dbb553940764c58ca6c359016c0d64a6b4f11",
+        "address": "0xa2d2e356c64dE9b0a5b4CFDfF2B4c82C0eC3D7A2",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 53,
+        "blockHash": "0xab5a33b7d60e0fcc67e3a5566f8ba5218f8444409837bd80f2c0850af549cb29"
+      },
+      {
+        "transactionIndex": 3,
+        "blockNumber": 14204531,
+        "transactionHash": "0x60bf258d211961057eb3d5029f7dbb553940764c58ca6c359016c0d64a6b4f11",
+        "address": "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x000000000000000000000000a2d2e356c64de9b0a5b4cfdff2b4c82c0ec3d7a200000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 54,
+        "blockHash": "0xab5a33b7d60e0fcc67e3a5566f8ba5218f8444409837bd80f2c0850af549cb29"
+      }
+    ],
+    "blockNumber": 14204531,
+    "cumulativeGasUsed": "3572717",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: BTC/USD [BTC-BTC]",
+    "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/bera-mainnet/MarketToken_OFT_WETH_WETH.json
+++ b/deployments/bera-mainnet/MarketToken_OFT_WETH_WETH.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xcc8754cb98e5b710906949dabf0f227d8065307a42bf3363e59030f336f6bd80",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+    "transactionIndex": 6,
+    "gasUsed": "3320198",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000000000000000000000000000000000000000000000000002000000000000000000000000002000000000000000000000000000000141000000000000000080000000000000000001020000000000000000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000008000000000000000000000000000000000000020004000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x7ee91a2915d7b356887e2a2ebf4cf77cbd5665edf16dea7138127d921b705285",
+    "transactionHash": "0xcc8754cb98e5b710906949dabf0f227d8065307a42bf3363e59030f336f6bd80",
+    "logs": [
+      {
+        "transactionIndex": 6,
+        "blockNumber": 14204521,
+        "transactionHash": "0xcc8754cb98e5b710906949dabf0f227d8065307a42bf3363e59030f336f6bd80",
+        "address": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 75,
+        "blockHash": "0x7ee91a2915d7b356887e2a2ebf4cf77cbd5665edf16dea7138127d921b705285"
+      },
+      {
+        "transactionIndex": 6,
+        "blockNumber": 14204521,
+        "transactionHash": "0xcc8754cb98e5b710906949dabf0f227d8065307a42bf3363e59030f336f6bd80",
+        "address": "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000002e6bf9bdd2a7872bdae170c13f34d64692f842c100000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 76,
+        "blockHash": "0x7ee91a2915d7b356887e2a2ebf4cf77cbd5665edf16dea7138127d921b705285"
+      }
+    ],
+    "blockNumber": 14204521,
+    "cumulativeGasUsed": "17409333",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: ETH/USD [WETH-WETH]",
+    "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/botanix-mainnet/MarketToken_OFT_BTC_BTC.json
+++ b/deployments/botanix-mainnet/MarketToken_OFT_BTC_BTC.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x9717D91D6943546A990Ae509a46655BA4Ad57649",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0x4e1a95dc26f024f6ab725b23b004d5ad14c0eec102649505bb6ef7afe38cfc62",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x9717D91D6943546A990Ae509a46655BA4Ad57649",
+    "transactionIndex": 8,
+    "gasUsed": "3320174",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000000141000000000000000080000000000000000000020000000000000000000800000000000000000000000100000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020004000000000000000000000000000000000000000000000040000000000000000",
+    "blockHash": "0x4662787f00b442a7033c6c704000a7314faa39205d339282db6ff7b9ae6b5e88",
+    "transactionHash": "0x4e1a95dc26f024f6ab725b23b004d5ad14c0eec102649505bb6ef7afe38cfc62",
+    "logs": [
+      {
+        "transactionIndex": 8,
+        "blockNumber": 3216617,
+        "transactionHash": "0x4e1a95dc26f024f6ab725b23b004d5ad14c0eec102649505bb6ef7afe38cfc62",
+        "address": "0x9717D91D6943546A990Ae509a46655BA4Ad57649",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 9,
+        "blockHash": "0x4662787f00b442a7033c6c704000a7314faa39205d339282db6ff7b9ae6b5e88"
+      },
+      {
+        "transactionIndex": 8,
+        "blockNumber": 3216617,
+        "transactionHash": "0x4e1a95dc26f024f6ab725b23b004d5ad14c0eec102649505bb6ef7afe38cfc62",
+        "address": "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000009717d91d6943546a990ae509a46655ba4ad5764900000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 10,
+        "blockHash": "0x4662787f00b442a7033c6c704000a7314faa39205d339282db6ff7b9ae6b5e88"
+      }
+    ],
+    "blockNumber": 3216617,
+    "cumulativeGasUsed": "3683793",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: BTC/USD [BTC-BTC]",
+    "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/botanix-mainnet/MarketToken_OFT_WETH_WETH.json
+++ b/deployments/botanix-mainnet/MarketToken_OFT_WETH_WETH.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x9f260cf66B3240e75C1bEe51a65936b513618159",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xde5f4b5cd24f614cda336e9fa455472927294df22663567e1c98a1213a5f0aef",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x9f260cf66B3240e75C1bEe51a65936b513618159",
+    "transactionIndex": 1,
+    "gasUsed": "3320198",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000004800000000000000000000000000000000000000000000000000002000000000000000000080000000000000000000000000000000000000141000000000000000080000000000000000000020000000000000000000800000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020004000000000000000000000000000000000000000000000000000000000000000",
+    "blockHash": "0x762bce59d8f5051e95365ecb53bf6a86940245890ae77ecc5011a3390e81c148",
+    "transactionHash": "0xde5f4b5cd24f614cda336e9fa455472927294df22663567e1c98a1213a5f0aef",
+    "logs": [
+      {
+        "transactionIndex": 1,
+        "blockNumber": 3216566,
+        "transactionHash": "0xde5f4b5cd24f614cda336e9fa455472927294df22663567e1c98a1213a5f0aef",
+        "address": "0x9f260cf66B3240e75C1bEe51a65936b513618159",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 3,
+        "blockHash": "0x762bce59d8f5051e95365ecb53bf6a86940245890ae77ecc5011a3390e81c148"
+      },
+      {
+        "transactionIndex": 1,
+        "blockNumber": 3216566,
+        "transactionHash": "0xde5f4b5cd24f614cda336e9fa455472927294df22663567e1c98a1213a5f0aef",
+        "address": "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000009f260cf66b3240e75c1bee51a65936b51361815900000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 4,
+        "blockHash": "0x762bce59d8f5051e95365ecb53bf6a86940245890ae77ecc5011a3390e81c148"
+      }
+    ],
+    "blockNumber": 3216566,
+    "cumulativeGasUsed": "3421303",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: ETH/USD [WETH-WETH]",
+    "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/bsc-mainnet/MarketToken_OFT_BTC_BTC.json
+++ b/deployments/bsc-mainnet/MarketToken_OFT_BTC_BTC.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xea99bab5088bd863a663a086af5202127142ed71f22af8430f8a929bc7dbea2d",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+    "transactionIndex": 88,
+    "gasUsed": "3320174",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000001000000000000000000000000000000000000000000002000000000000000000000000002000000000000000000000000000000001000000000000000080000000000000000001020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000008000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x2bcff7233f2f2b7ea2f726208bd32df208c22827fc85d0955bdcba54df793dc3",
+    "transactionHash": "0xea99bab5088bd863a663a086af5202127142ed71f22af8430f8a929bc7dbea2d",
+    "logs": [
+      {
+        "transactionIndex": 88,
+        "blockNumber": 71229413,
+        "transactionHash": "0xea99bab5088bd863a663a086af5202127142ed71f22af8430f8a929bc7dbea2d",
+        "address": "0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 808,
+        "blockHash": "0x2bcff7233f2f2b7ea2f726208bd32df208c22827fc85d0955bdcba54df793dc3"
+      },
+      {
+        "transactionIndex": 88,
+        "blockNumber": 71229413,
+        "transactionHash": "0xea99bab5088bd863a663a086af5202127142ed71f22af8430f8a929bc7dbea2d",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000002e6bf9bdd2a7872bdae170c13f34d64692f842c100000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 809,
+        "blockHash": "0x2bcff7233f2f2b7ea2f726208bd32df208c22827fc85d0955bdcba54df793dc3"
+      }
+    ],
+    "blockNumber": 71229413,
+    "cumulativeGasUsed": "22122439",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: BTC/USD [BTC-BTC]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/bsc-mainnet/MarketToken_OFT_WETH_WETH.json
+++ b/deployments/bsc-mainnet/MarketToken_OFT_WETH_WETH.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xe10e2145d2cb119c56c4219ddab5021223a9d405278469dca0086edea71698f2",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+    "transactionIndex": 123,
+    "gasUsed": "3320198",
+    "logsBloom": "0x40000000000000000000000000008000000000000800000000800000001800000000000000000000000000000000000000000002000000000000000000000800000000000000000000000000000000000001000000000000000080000000000000000000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0xfba5d3c474f15c32d3285fe5326cde1345e7b14343d670332430a8e03d503d07",
+    "transactionHash": "0xe10e2145d2cb119c56c4219ddab5021223a9d405278469dca0086edea71698f2",
+    "logs": [
+      {
+        "transactionIndex": 123,
+        "blockNumber": 71229053,
+        "transactionHash": "0xe10e2145d2cb119c56c4219ddab5021223a9d405278469dca0086edea71698f2",
+        "address": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 696,
+        "blockHash": "0xfba5d3c474f15c32d3285fe5326cde1345e7b14343d670332430a8e03d503d07"
+      },
+      {
+        "transactionIndex": 123,
+        "blockNumber": 71229053,
+        "transactionHash": "0xe10e2145d2cb119c56c4219ddab5021223a9d405278469dca0086edea71698f2",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000005ece4d3f43d3bd8cbffc1d2ce851e7605d403d3c00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 697,
+        "blockHash": "0xfba5d3c474f15c32d3285fe5326cde1345e7b14343d670332430a8e03d503d07"
+      }
+    ],
+    "blockNumber": 71229053,
+    "cumulativeGasUsed": "21990124",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: ETH/USD [WETH-WETH]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/ethereum-mainnet/MarketToken_OFT_BTC_BTC.json
+++ b/deployments/ethereum-mainnet/MarketToken_OFT_BTC_BTC.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xdd0ed67cb85cb9d269e5235d2da6845abdc59456483ec7ad53bd40898f6c499f",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+    "transactionIndex": 91,
+    "gasUsed": "3320174",
+    "logsBloom": "0x40000000000000000000000000008000000000000800000000800000001800000000000000000000000000000000000000000002000000000000000000000800000000000000000000000000000000000001000000000000000080000000000000000000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x6e779294477d3e8477c78caa4dd04eb0a92fa39432024e1948c66e9bf0f2831c",
+    "transactionHash": "0xdd0ed67cb85cb9d269e5235d2da6845abdc59456483ec7ad53bd40898f6c499f",
+    "logs": [
+      {
+        "transactionIndex": 91,
+        "blockNumber": 23986765,
+        "transactionHash": "0xdd0ed67cb85cb9d269e5235d2da6845abdc59456483ec7ad53bd40898f6c499f",
+        "address": "0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 478,
+        "blockHash": "0x6e779294477d3e8477c78caa4dd04eb0a92fa39432024e1948c66e9bf0f2831c"
+      },
+      {
+        "transactionIndex": 91,
+        "blockNumber": 23986765,
+        "transactionHash": "0xdd0ed67cb85cb9d269e5235d2da6845abdc59456483ec7ad53bd40898f6c499f",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000005ece4d3f43d3bd8cbffc1d2ce851e7605d403d3c00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 479,
+        "blockHash": "0x6e779294477d3e8477c78caa4dd04eb0a92fa39432024e1948c66e9bf0f2831c"
+      }
+    ],
+    "blockNumber": 23986765,
+    "cumulativeGasUsed": "17416452",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: BTC/USD [BTC-BTC]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/deployments/ethereum-mainnet/MarketToken_OFT_WETH_WETH.json
+++ b/deployments/ethereum-mainnet/MarketToken_OFT_WETH_WETH.json
@@ -1,0 +1,2438 @@
+{
+  "address": "0x0B335e18Ab68Ccd2E8946A6E785D8bE65F413103",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_lzEndpoint",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ECDSAInvalidSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "length",
+          "type": "uint256"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureLength",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ECDSAInvalidSignatureS",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC2612ExpiredSignature",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "ERC2612InvalidSigner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentNonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvalidAccountNonce",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidDelegate",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidEndpointCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidLocalDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "options",
+          "type": "bytes"
+        }
+      ],
+      "name": "InvalidOptions",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShortString",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LzTokenUnavailable",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "NoPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "msgValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughNative",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        }
+      ],
+      "name": "OnlyEndpoint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "sender",
+          "type": "bytes32"
+        }
+      ],
+      "name": "OnlyPeer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlySelf",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "OwnableUnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "SimulationResult",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountLD",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "SlippageExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "str",
+          "type": "string"
+        }
+      ],
+      "name": "StringTooLong",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EIP712DomainChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "EnforcedOptionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "inspector",
+          "type": "address"
+        }
+      ],
+      "name": "MsgInspectorSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "srcEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "toAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "guid",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "dstEid",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "fromAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountSentLD",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountReceivedLD",
+          "type": "uint256"
+        }
+      ],
+      "name": "OFTSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PeerSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "preCrimeAddress",
+          "type": "address"
+        }
+      ],
+      "name": "PreCrimeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DOMAIN_SEPARATOR",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SEND_AND_CALL",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "origin",
+          "type": "tuple"
+        }
+      ],
+      "name": "allowInitializePath",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvalRequired",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "_msgType",
+          "type": "uint16"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraOptions",
+          "type": "bytes"
+        }
+      ],
+      "name": "combineOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimalConversionRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "eip712Domain",
+      "outputs": [
+        {
+          "internalType": "bytes1",
+          "name": "fields",
+          "type": "bytes1"
+        },
+        {
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "version",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "chainId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "verifyingContract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "salt",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "extensions",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endpoint",
+      "outputs": [
+        {
+          "internalType": "contract ILayerZeroEndpointV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint16",
+          "name": "msgType",
+          "type": "uint16"
+        }
+      ],
+      "name": "enforcedOptions",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "enforcedOption",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        }
+      ],
+      "name": "isComposeMsgSender",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "isPeer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceive",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "uint32",
+                  "name": "srcEid",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "sender",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "nonce",
+                  "type": "uint64"
+                }
+              ],
+              "internalType": "struct Origin",
+              "name": "origin",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "executor",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "message",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct InboundPacket[]",
+          "name": "_packets",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "lzReceiveAndRevert",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "srcEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "sender",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct Origin",
+          "name": "_origin",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_guid",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_message",
+          "type": "bytes"
+        },
+        {
+          "internalType": "address",
+          "name": "_executor",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_extraData",
+          "type": "bytes"
+        }
+      ],
+      "name": "lzReceiveSimulate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "msgInspector",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "nextNonce",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "nonce",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "nonces",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oApp",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oAppVersion",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "senderVersion",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "receiverVersion",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "oftVersion",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "uint64",
+          "name": "version",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "eid",
+          "type": "uint32"
+        }
+      ],
+      "name": "peers",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "peer",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "v",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "r",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "s",
+          "type": "bytes32"
+        }
+      ],
+      "name": "permit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "preCrime",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        }
+      ],
+      "name": "quoteOFT",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxAmountLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTLimit",
+          "name": "oftLimit",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "feeAmountLD",
+              "type": "int256"
+            },
+            {
+              "internalType": "string",
+              "name": "description",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct OFTFeeDetail[]",
+          "name": "oftFeeDetails",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bool",
+          "name": "_payInLzToken",
+          "type": "bool"
+        }
+      ],
+      "name": "quoteSend",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "msgFee",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "dstEid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "to",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minAmountLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "extraOptions",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "composeMsg",
+              "type": "bytes"
+            },
+            {
+              "internalType": "bytes",
+              "name": "oftCmd",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct SendParam",
+          "name": "_sendParam",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "nativeFee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lzTokenFee",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct MessagingFee",
+          "name": "_fee",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_refundAddress",
+          "type": "address"
+        }
+      ],
+      "name": "send",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "guid",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "nonce",
+              "type": "uint64"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "nativeFee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "lzTokenFee",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct MessagingFee",
+              "name": "fee",
+              "type": "tuple"
+            }
+          ],
+          "internalType": "struct MessagingReceipt",
+          "name": "msgReceipt",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amountSentLD",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountReceivedLD",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct OFTReceipt",
+          "name": "oftReceipt",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_delegate",
+          "type": "address"
+        }
+      ],
+      "name": "setDelegate",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "eid",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint16",
+              "name": "msgType",
+              "type": "uint16"
+            },
+            {
+              "internalType": "bytes",
+              "name": "options",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct EnforcedOptionParam[]",
+          "name": "_enforcedOptions",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "setEnforcedOptions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_msgInspector",
+          "type": "address"
+        }
+      ],
+      "name": "setMsgInspector",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "_eid",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_peer",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setPeer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_preCrime",
+          "type": "address"
+        }
+      ],
+      "name": "setPreCrime",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sharedDecimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "token",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "transactionHash": "0xc0f57aaa72ddc85162a04846994d5bc86e26407041f6452253e38abeefe95c9a",
+  "receipt": {
+    "to": null,
+    "from": "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2",
+    "contractAddress": "0x0B335e18Ab68Ccd2E8946A6E785D8bE65F413103",
+    "transactionIndex": 68,
+    "gasUsed": "3320198",
+    "logsBloom": "0x00000000000000000000000000008000000000000800000000800000001000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000021000000000000000080000000000000800000020000000000000000000800000000000010000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000002000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000010000000000000000000000",
+    "blockHash": "0x182962e7a5f989f115ab6f5229b0c905c5815ed89905169cefbdf11f0ae65f6e",
+    "transactionHash": "0xc0f57aaa72ddc85162a04846994d5bc86e26407041f6452253e38abeefe95c9a",
+    "logs": [
+      {
+        "transactionIndex": 68,
+        "blockNumber": 23986742,
+        "transactionHash": "0xc0f57aaa72ddc85162a04846994d5bc86e26407041f6452253e38abeefe95c9a",
+        "address": "0x0B335e18Ab68Ccd2E8946A6E785D8bE65F413103",
+        "topics": [
+          "0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0",
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x00000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2"
+        ],
+        "data": "0x",
+        "logIndex": 108,
+        "blockHash": "0x182962e7a5f989f115ab6f5229b0c905c5815ed89905169cefbdf11f0ae65f6e"
+      },
+      {
+        "transactionIndex": 68,
+        "blockNumber": 23986742,
+        "transactionHash": "0xc0f57aaa72ddc85162a04846994d5bc86e26407041f6452253e38abeefe95c9a",
+        "address": "0x1a44076050125825900e736c501f859c50fE728c",
+        "topics": [
+          "0x6ee10e9ed4d6ce9742703a498707862f4b00f1396a87195eb93267b3d7983981"
+        ],
+        "data": "0x0000000000000000000000000b335e18ab68ccd2e8946a6e785d8be65f41310300000000000000000000000094adace1d0156f4deb785c4cdae758e53a8fbac2",
+        "logIndex": 109,
+        "blockHash": "0x182962e7a5f989f115ab6f5229b0c905c5815ed89905169cefbdf11f0ae65f6e"
+      }
+    ],
+    "blockNumber": 23986742,
+    "cumulativeGasUsed": "9053217",
+    "status": 1,
+    "byzantium": true
+  },
+  "args": [
+    "GMX Market",
+    "GM: ETH/USD [WETH-WETH]",
+    "0x1a44076050125825900e736c501f859c50fE728c",
+    "0x94adACE1d0156f4DEb785C4cdae758e53a8FbaC2"
+  ],
+  "numDeployments": 1,
+  "solcInputHash": "aa502186041ff6b02b7a933cd34dd3ba",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.22+commit.4fc1097e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"_lzEndpoint\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ECDSAInvalidSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"ECDSAInvalidSignatureLength\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"ECDSAInvalidSignatureS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"}],\"name\":\"ERC2612ExpiredSignature\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"ERC2612InvalidSigner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"currentNonce\",\"type\":\"uint256\"}],\"name\":\"InvalidAccountNonce\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidDelegate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidEndpointCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidLocalDecimals\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"name\":\"InvalidOptions\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidShortString\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"LzTokenUnavailable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"NoPeer\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"msgValue\",\"type\":\"uint256\"}],\"name\":\"NotEnoughNative\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"OnlyEndpoint\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"}],\"name\":\"OnlyPeer\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OnlySelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OwnableInvalidOwner\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"OwnableUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"result\",\"type\":\"bytes\"}],\"name\":\"SimulationResult\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"}],\"name\":\"SlippageExceeded\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"StringTooLong\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"indexed\":false,\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"EnforcedOptionSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"inspector\",\"type\":\"address\"}],\"name\":\"MsgInspectorSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"toAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTReceived\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"fromAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"name\":\"OFTSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"name\":\"PeerSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"preCrimeAddress\",\"type\":\"address\"}],\"name\":\"PreCrimeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SEND_AND_CALL\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"}],\"name\":\"allowInitializePath\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"approvalRequired\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"_extraOptions\",\"type\":\"bytes\"}],\"name\":\"combineOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimalConversionRate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"endpoint\",\"outputs\":[{\"internalType\":\"contract ILayerZeroEndpointV2\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"}],\"name\":\"enforcedOptions\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"enforcedOption\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"}],\"name\":\"isComposeMsgSender\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"isPeer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceive\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"origin\",\"type\":\"tuple\"},{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"message\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"extraData\",\"type\":\"bytes\"}],\"internalType\":\"struct InboundPacket[]\",\"name\":\"_packets\",\"type\":\"tuple[]\"}],\"name\":\"lzReceiveAndRevert\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"srcEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"sender\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"internalType\":\"struct Origin\",\"name\":\"_origin\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"_guid\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"_message\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"_executor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"lzReceiveSimulate\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"msgInspector\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"name\":\"nextNonce\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oApp\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oAppVersion\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"senderVersion\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"receiverVersion\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"oftVersion\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"},{\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"}],\"name\":\"peers\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"peer\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"preCrime\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"}],\"name\":\"quoteOFT\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAmountLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTLimit\",\"name\":\"oftLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"int256\",\"name\":\"feeAmountLD\",\"type\":\"int256\"},{\"internalType\":\"string\",\"name\":\"description\",\"type\":\"string\"}],\"internalType\":\"struct OFTFeeDetail[]\",\"name\":\"oftFeeDetails\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"internalType\":\"bool\",\"name\":\"_payInLzToken\",\"type\":\"bool\"}],\"name\":\"quoteSend\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"msgFee\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"dstEid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"to\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"amountLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"minAmountLD\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"extraOptions\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"composeMsg\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"oftCmd\",\"type\":\"bytes\"}],\"internalType\":\"struct SendParam\",\"name\":\"_sendParam\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"_fee\",\"type\":\"tuple\"},{\"internalType\":\"address\",\"name\":\"_refundAddress\",\"type\":\"address\"}],\"name\":\"send\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"guid\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"nonce\",\"type\":\"uint64\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"nativeFee\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"lzTokenFee\",\"type\":\"uint256\"}],\"internalType\":\"struct MessagingFee\",\"name\":\"fee\",\"type\":\"tuple\"}],\"internalType\":\"struct MessagingReceipt\",\"name\":\"msgReceipt\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"amountSentLD\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"amountReceivedLD\",\"type\":\"uint256\"}],\"internalType\":\"struct OFTReceipt\",\"name\":\"oftReceipt\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_delegate\",\"type\":\"address\"}],\"name\":\"setDelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint32\",\"name\":\"eid\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"msgType\",\"type\":\"uint16\"},{\"internalType\":\"bytes\",\"name\":\"options\",\"type\":\"bytes\"}],\"internalType\":\"struct EnforcedOptionParam[]\",\"name\":\"_enforcedOptions\",\"type\":\"tuple[]\"}],\"name\":\"setEnforcedOptions\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_msgInspector\",\"type\":\"address\"}],\"name\":\"setMsgInspector\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_eid\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"_peer\",\"type\":\"bytes32\"}],\"name\":\"setPeer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_preCrime\",\"type\":\"address\"}],\"name\":\"setPreCrime\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sharedDecimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"token\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"ECDSAInvalidSignature()\":[{\"details\":\"The signature derives the `address(0)`.\"}],\"ECDSAInvalidSignatureLength(uint256)\":[{\"details\":\"The signature has an invalid length.\"}],\"ECDSAInvalidSignatureS(bytes32)\":[{\"details\":\"The signature has an S value that is in the upper half order.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC2612ExpiredSignature(uint256)\":[{\"details\":\"Permit deadline has expired.\"}],\"ERC2612InvalidSigner(address,address)\":[{\"details\":\"Mismatched signature.\"}],\"InvalidAccountNonce(address,uint256)\":[{\"details\":\"The nonce used for an `account` is not the expected current nonce.\"}],\"OwnableInvalidOwner(address)\":[{\"details\":\"The owner is not a valid owner account. (eg. `address(0)`)\"}],\"OwnableUnauthorizedAccount(address)\":[{\"details\":\"The caller account is not authorized to perform an operation.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"PreCrimeSet(address)\":{\"details\":\"Emitted when the preCrime contract address is set.\",\"params\":{\"preCrimeAddress\":\"The address of the preCrime contract.\"}},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"}},\"kind\":\"dev\",\"methods\":{\"DOMAIN_SEPARATOR()\":{\"details\":\"Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\"},\"allowInitializePath((uint32,bytes32,uint64))\":{\"details\":\"This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.\",\"params\":{\"origin\":\"The origin information containing the source endpoint and sender address.\"},\"returns\":{\"_0\":\"Whether the path has been initialized.\"}},\"allowance(address,address)\":{\"details\":\"See {IERC20-allowance}.\"},\"approvalRequired()\":{\"details\":\"In the case of OFT where the contract IS the token, approval is NOT required.\",\"returns\":{\"_0\":\"requiresApproval Needs approval of the underlying token implementation.\"}},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"See {IERC20-balanceOf}.\"},\"combineOptions(uint32,uint16,bytes)\":{\"details\":\"If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_extraOptions\":\"Additional options passed by the caller.\",\"_msgType\":\"The OAPP message type.\"},\"returns\":{\"_0\":\"options The combination of caller specified options AND enforced options.\"}},\"constructor\":{\"details\":\"Using msg.sender instead of _delegate in Ownable to avoid via-ir\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"details\":\"_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.\",\"params\":{\"_sender\":\"The sender address.\"},\"returns\":{\"_0\":\"isSender Is a valid sender.\"}},\"isPeer(uint32,bytes32)\":{\"details\":\"Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\",\"params\":{\"_eid\":\"The endpoint ID to check.\",\"_peer\":\"The peer to check.\"},\"returns\":{\"_0\":\"Whether the peer passed is considered 'trusted' by the OApp.\"}},\"lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.\",\"params\":{\"_executor\":\"The address of the executor for the received message.\",\"_extraData\":\"Additional arbitrary data provided by the corresponding executor.\",\"_guid\":\"The unique identifier for the received LayerZero message.\",\"_message\":\"The payload of the received message.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])\":{\"details\":\"Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.\",\"params\":{\"_packets\":\"An array of InboundPacket objects representing received packets to be delivered.\"}},\"lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)\":{\"details\":\"Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.\",\"params\":{\"_executor\":\"The executor address for the packet.\",\"_extraData\":\"Additional data for the packet.\",\"_guid\":\"The unique identifier of the packet.\",\"_message\":\"The message payload of the packet.\",\"_origin\":\"The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message.\"}},\"name()\":{\"details\":\"Returns the name of the token.\"},\"nextNonce(uint32,bytes32)\":{\"details\":\"_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\",\"returns\":{\"nonce\":\"The next nonce.\"}},\"nonces(address)\":{\"details\":\"Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times.\"},\"oApp()\":{\"details\":\"Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.\",\"returns\":{\"_0\":\"The address of the OApp contract.\"}},\"oAppVersion()\":{\"returns\":{\"receiverVersion\":\"The version of the OAppReceiver.sol implementation.\",\"senderVersion\":\"The version of the OAppSender.sol implementation.\"}},\"oftVersion()\":{\"details\":\"interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\",\"returns\":{\"interfaceId\":\"The interface ID.\",\"version\":\"The version.\"}},\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"permit(address,address,uint256,uint256,uint8,bytes32,bytes32)\":{\"details\":\"Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"params\":{\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"oftFeeDetails\":\"The details of OFT fees.\",\"oftLimit\":\"The OFT limit information.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"details\":\"MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.\",\"params\":{\"_payInLzToken\":\"Flag indicating whether the caller is paying in the LZ token.\",\"_sendParam\":\"The parameters for the send() operation.\"},\"returns\":{\"msgFee\":\"The calculated LayerZero messaging fee from the send() operation.\"}},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)\":{\"details\":\"Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.\",\"params\":{\"_fee\":\"The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.\",\"_refundAddress\":\"The address to receive any excess funds.\",\"_sendParam\":\"The parameters for the send operation.\"},\"returns\":{\"msgReceipt\":\"The receipt for the send operation.\",\"oftReceipt\":\"The OFT receipt information.\"}},\"setDelegate(address)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\",\"params\":{\"_delegate\":\"The address of the delegate to be set.\"}},\"setEnforcedOptions((uint32,uint16,bytes)[])\":{\"details\":\"Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\",\"params\":{\"_enforcedOptions\":\"An array of EnforcedOptionParam structures specifying enforced options.\"}},\"setMsgInspector(address)\":{\"details\":\"Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.\",\"params\":{\"_msgInspector\":\"The address of the message inspector.\"}},\"setPeer(uint32,bytes32)\":{\"details\":\"Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.\",\"params\":{\"_eid\":\"The endpoint ID.\",\"_peer\":\"The address of the peer to be associated with the corresponding endpoint.\"}},\"setPreCrime(address)\":{\"details\":\"Sets the preCrime contract address.\",\"params\":{\"_preCrime\":\"The address of the preCrime contract.\"}},\"sharedDecimals()\":{\"details\":\"Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\",\"returns\":{\"_0\":\"The shared decimals of the OFT.\"}},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"token()\":{\"details\":\"Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.\",\"returns\":{\"_0\":\"The address of the OFT token.\"}},\"totalSupply()\":{\"details\":\"See {IERC20-totalSupply}.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"allowInitializePath((uint32,bytes32,uint64))\":{\"notice\":\"Checks if the path initialization is allowed based on the provided origin.\"},\"approvalRequired()\":{\"notice\":\"Indicates whether the OFT contract requires approval of the 'token()' to send.\"},\"combineOptions(uint32,uint16,bytes)\":{\"notice\":\"Combines options for a given endpoint and message type.\"},\"endpoint()\":{\"notice\":\"Retrieves the LayerZero endpoint associated with the OApp.\"},\"isComposeMsgSender((uint32,bytes32,uint64),bytes,address)\":{\"notice\":\"Indicates whether an address is an approved composeMsg sender to the Endpoint.\"},\"nextNonce(uint32,bytes32)\":{\"notice\":\"Retrieves the next nonce for a given source endpoint and sender address.\"},\"oAppVersion()\":{\"notice\":\"Retrieves the OApp version information.\"},\"oftVersion()\":{\"notice\":\"Retrieves interfaceID and the version of the OFT.\"},\"peers(uint32)\":{\"notice\":\"Retrieves the peer (OApp) associated with a corresponding endpoint.\"},\"quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))\":{\"notice\":\"Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\"},\"quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)\":{\"notice\":\"Provides a quote for the send() operation.\"},\"setDelegate(address)\":{\"notice\":\"Sets the delegate address for the OApp.\"},\"setPeer(uint32,bytes32)\":{\"notice\":\"Sets the peer address (OApp instance) for a corresponding endpoint.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/GM/MarketToken_OFT.sol\":\"MarketToken_OFT\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\",\"useLiteralContent\":true},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IMessageLibManager } from \\\"./IMessageLibManager.sol\\\";\\nimport { IMessagingComposer } from \\\"./IMessagingComposer.sol\\\";\\nimport { IMessagingChannel } from \\\"./IMessagingChannel.sol\\\";\\nimport { IMessagingContext } from \\\"./IMessagingContext.sol\\\";\\n\\nstruct MessagingParams {\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes message;\\n    bytes options;\\n    bool payInLzToken;\\n}\\n\\nstruct MessagingReceipt {\\n    bytes32 guid;\\n    uint64 nonce;\\n    MessagingFee fee;\\n}\\n\\nstruct MessagingFee {\\n    uint256 nativeFee;\\n    uint256 lzTokenFee;\\n}\\n\\nstruct Origin {\\n    uint32 srcEid;\\n    bytes32 sender;\\n    uint64 nonce;\\n}\\n\\ninterface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessagingChannel, IMessagingContext {\\n    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);\\n\\n    event PacketVerified(Origin origin, address receiver, bytes32 payloadHash);\\n\\n    event PacketDelivered(Origin origin, address receiver);\\n\\n    event LzReceiveAlert(\\n        address indexed receiver,\\n        address indexed executor,\\n        Origin origin,\\n        bytes32 guid,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    event LzTokenSet(address token);\\n\\n    event DelegateSet(address sender, address delegate);\\n\\n    function quote(MessagingParams calldata _params, address _sender) external view returns (MessagingFee memory);\\n\\n    function send(\\n        MessagingParams calldata _params,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory);\\n\\n    function verify(Origin calldata _origin, address _receiver, bytes32 _payloadHash) external;\\n\\n    function verifiable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function initializable(Origin calldata _origin, address _receiver) external view returns (bool);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        address _receiver,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n\\n    // oapp can burn messages partially by calling this function with its own business logic if messages are verified in order\\n    function clear(address _oapp, Origin calldata _origin, bytes32 _guid, bytes calldata _message) external;\\n\\n    function setLzToken(address _lzToken) external;\\n\\n    function lzToken() external view returns (address);\\n\\n    function nativeToken() external view returns (address);\\n\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0xf7f941bee89ea6369950fe54e8ac476ae6478b958b20fc0e8a83e8ff1364eac3\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { Origin } from \\\"./ILayerZeroEndpointV2.sol\\\";\\n\\ninterface ILayerZeroReceiver {\\n    function allowInitializePath(Origin calldata _origin) external view returns (bool);\\n\\n    function nextNonce(uint32 _eid, bytes32 _sender) external view returns (uint64);\\n\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x9641abba8d53b08bb517d1b74801dd15ea7b84d77a6719085bd96c8ea94e3ca0\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { IERC165 } from \\\"@openzeppelin/contracts/utils/introspection/IERC165.sol\\\";\\n\\nimport { SetConfigParam } from \\\"./IMessageLibManager.sol\\\";\\n\\nenum MessageLibType {\\n    Send,\\n    Receive,\\n    SendAndReceive\\n}\\n\\ninterface IMessageLib is IERC165 {\\n    function setConfig(address _oapp, SetConfigParam[] calldata _config) external;\\n\\n    function getConfig(uint32 _eid, address _oapp, uint32 _configType) external view returns (bytes memory config);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    // message libs of same major version are compatible\\n    function version() external view returns (uint64 major, uint8 minor, uint8 endpointVersion);\\n\\n    function messageLibType() external view returns (MessageLibType);\\n}\\n\",\"keccak256\":\"0x5cf5f24751b4e3ea1c9c5ded07cedfdfd62566b6daaffcc0144733859c9dba0c\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nstruct SetConfigParam {\\n    uint32 eid;\\n    uint32 configType;\\n    bytes config;\\n}\\n\\ninterface IMessageLibManager {\\n    struct Timeout {\\n        address lib;\\n        uint256 expiry;\\n    }\\n\\n    event LibraryRegistered(address newLib);\\n    event DefaultSendLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibrarySet(uint32 eid, address newLib);\\n    event DefaultReceiveLibraryTimeoutSet(uint32 eid, address oldLib, uint256 expiry);\\n    event SendLibrarySet(address sender, uint32 eid, address newLib);\\n    event ReceiveLibrarySet(address receiver, uint32 eid, address newLib);\\n    event ReceiveLibraryTimeoutSet(address receiver, uint32 eid, address oldLib, uint256 timeout);\\n\\n    function registerLibrary(address _lib) external;\\n\\n    function isRegisteredLibrary(address _lib) external view returns (bool);\\n\\n    function getRegisteredLibraries() external view returns (address[] memory);\\n\\n    function setDefaultSendLibrary(uint32 _eid, address _newLib) external;\\n\\n    function defaultSendLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibrary(uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function defaultReceiveLibrary(uint32 _eid) external view returns (address);\\n\\n    function setDefaultReceiveLibraryTimeout(uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function defaultReceiveLibraryTimeout(uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function isSupportedEid(uint32 _eid) external view returns (bool);\\n\\n    function isValidReceiveLibrary(address _receiver, uint32 _eid, address _lib) external view returns (bool);\\n\\n    /// ------------------- OApp interfaces -------------------\\n    function setSendLibrary(address _oapp, uint32 _eid, address _newLib) external;\\n\\n    function getSendLibrary(address _sender, uint32 _eid) external view returns (address lib);\\n\\n    function isDefaultSendLibrary(address _sender, uint32 _eid) external view returns (bool);\\n\\n    function setReceiveLibrary(address _oapp, uint32 _eid, address _newLib, uint256 _gracePeriod) external;\\n\\n    function getReceiveLibrary(address _receiver, uint32 _eid) external view returns (address lib, bool isDefault);\\n\\n    function setReceiveLibraryTimeout(address _oapp, uint32 _eid, address _lib, uint256 _expiry) external;\\n\\n    function receiveLibraryTimeout(address _receiver, uint32 _eid) external view returns (address lib, uint256 expiry);\\n\\n    function setConfig(address _oapp, address _lib, SetConfigParam[] calldata _params) external;\\n\\n    function getConfig(\\n        address _oapp,\\n        address _lib,\\n        uint32 _eid,\\n        uint32 _configType\\n    ) external view returns (bytes memory config);\\n}\\n\",\"keccak256\":\"0x919b37133adff4dc528e3061deb2789c3149971b530c61e556fb3d09ab315dfc\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingChannel.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingChannel {\\n    event InboundNonceSkipped(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce);\\n    event PacketNilified(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n    event PacketBurnt(uint32 srcEid, bytes32 sender, address receiver, uint64 nonce, bytes32 payloadHash);\\n\\n    function eid() external view returns (uint32);\\n\\n    // this is an emergency function if a message cannot be verified for some reasons\\n    // required to provide _nextNonce to avoid race condition\\n    function skip(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce) external;\\n\\n    function nilify(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function burn(address _oapp, uint32 _srcEid, bytes32 _sender, uint64 _nonce, bytes32 _payloadHash) external;\\n\\n    function nextGuid(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (bytes32);\\n\\n    function inboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n\\n    function outboundNonce(address _sender, uint32 _dstEid, bytes32 _receiver) external view returns (uint64);\\n\\n    function inboundPayloadHash(\\n        address _receiver,\\n        uint32 _srcEid,\\n        bytes32 _sender,\\n        uint64 _nonce\\n    ) external view returns (bytes32);\\n\\n    function lazyInboundNonce(address _receiver, uint32 _srcEid, bytes32 _sender) external view returns (uint64);\\n}\\n\",\"keccak256\":\"0x0878f64dffebf58c4165569416372f40860fab546b88cd926eba0d5cb6d8d972\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingComposer.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingComposer {\\n    event ComposeSent(address from, address to, bytes32 guid, uint16 index, bytes message);\\n    event ComposeDelivered(address from, address to, bytes32 guid, uint16 index);\\n    event LzComposeAlert(\\n        address indexed from,\\n        address indexed to,\\n        address indexed executor,\\n        bytes32 guid,\\n        uint16 index,\\n        uint256 gas,\\n        uint256 value,\\n        bytes message,\\n        bytes extraData,\\n        bytes reason\\n    );\\n\\n    function composeQueue(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index\\n    ) external view returns (bytes32 messageHash);\\n\\n    function sendCompose(address _to, bytes32 _guid, uint16 _index, bytes calldata _message) external;\\n\\n    function lzCompose(\\n        address _from,\\n        address _to,\\n        bytes32 _guid,\\n        uint16 _index,\\n        bytes calldata _message,\\n        bytes calldata _extraData\\n    ) external payable;\\n}\\n\",\"keccak256\":\"0x85bc7090134529ec474866dc4bb1c48692d518c756eb0a961c82574829c51901\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessagingContext.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\ninterface IMessagingContext {\\n    function isSendingMessage() external view returns (bool);\\n\\n    function getSendContext() external view returns (uint32 dstEid, address sender);\\n}\\n\",\"keccak256\":\"0xff0c546c2813dae3e440882f46b377375f7461b0714efd80bd3f0c6e5cb8da4e\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity >=0.8.0;\\n\\nimport { MessagingFee } from \\\"./ILayerZeroEndpointV2.sol\\\";\\nimport { IMessageLib } from \\\"./IMessageLib.sol\\\";\\n\\nstruct Packet {\\n    uint64 nonce;\\n    uint32 srcEid;\\n    address sender;\\n    uint32 dstEid;\\n    bytes32 receiver;\\n    bytes32 guid;\\n    bytes message;\\n}\\n\\ninterface ISendLib is IMessageLib {\\n    function send(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external returns (MessagingFee memory, bytes memory encodedPacket);\\n\\n    function quote(\\n        Packet calldata _packet,\\n        bytes calldata _options,\\n        bool _payInLzToken\\n    ) external view returns (MessagingFee memory);\\n\\n    function setTreasury(address _treasury) external;\\n\\n    function withdrawFee(address _to, uint256 _amount) external;\\n\\n    function withdrawLzTokenFee(address _lzToken, address _to, uint256 _amount) external;\\n}\\n\",\"keccak256\":\"0xf1c07bc61e7b1dce195ed12d50f87980fbf2d63cac1326fd28287f55fe0ba625\",\"license\":\"MIT\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nlibrary AddressCast {\\n    error AddressCast_InvalidSizeForAddress();\\n    error AddressCast_InvalidAddress();\\n\\n    function toBytes32(bytes calldata _addressBytes) internal pure returns (bytes32 result) {\\n        if (_addressBytes.length > 32) revert AddressCast_InvalidAddress();\\n        result = bytes32(_addressBytes);\\n        unchecked {\\n            uint256 offset = 32 - _addressBytes.length;\\n            result = result >> (offset * 8);\\n        }\\n    }\\n\\n    function toBytes32(address _address) internal pure returns (bytes32 result) {\\n        result = bytes32(uint256(uint160(_address)));\\n    }\\n\\n    function toBytes(bytes32 _addressBytes32, uint256 _size) internal pure returns (bytes memory result) {\\n        if (_size == 0 || _size > 32) revert AddressCast_InvalidSizeForAddress();\\n        result = new bytes(_size);\\n        unchecked {\\n            uint256 offset = 256 - _size * 8;\\n            assembly {\\n                mstore(add(result, 32), shl(offset, _addressBytes32))\\n            }\\n        }\\n    }\\n\\n    function toAddress(bytes32 _addressBytes32) internal pure returns (address result) {\\n        result = address(uint160(uint256(_addressBytes32)));\\n    }\\n\\n    function toAddress(bytes calldata _addressBytes) internal pure returns (address result) {\\n        if (_addressBytes.length != 20) revert AddressCast_InvalidAddress();\\n        result = address(bytes20(_addressBytes));\\n    }\\n}\\n\",\"keccak256\":\"0x2ebbcaaab3554edcd41b581f1a72ac1806afbfb8047d0d47ff098f9af30d6deb\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\":{\"content\":\"// SPDX-License-Identifier: LZBL-1.2\\n\\npragma solidity ^0.8.20;\\n\\nimport { Packet } from \\\"../../interfaces/ISendLib.sol\\\";\\nimport { AddressCast } from \\\"../../libs/AddressCast.sol\\\";\\n\\nlibrary PacketV1Codec {\\n    using AddressCast for address;\\n    using AddressCast for bytes32;\\n\\n    uint8 internal constant PACKET_VERSION = 1;\\n\\n    // header (version + nonce + path)\\n    // version\\n    uint256 private constant PACKET_VERSION_OFFSET = 0;\\n    //    nonce\\n    uint256 private constant NONCE_OFFSET = 1;\\n    //    path\\n    uint256 private constant SRC_EID_OFFSET = 9;\\n    uint256 private constant SENDER_OFFSET = 13;\\n    uint256 private constant DST_EID_OFFSET = 45;\\n    uint256 private constant RECEIVER_OFFSET = 49;\\n    // payload (guid + message)\\n    uint256 private constant GUID_OFFSET = 81; // keccak256(nonce + path)\\n    uint256 private constant MESSAGE_OFFSET = 113;\\n\\n    function encode(Packet memory _packet) internal pure returns (bytes memory encodedPacket) {\\n        encodedPacket = abi.encodePacked(\\n            PACKET_VERSION,\\n            _packet.nonce,\\n            _packet.srcEid,\\n            _packet.sender.toBytes32(),\\n            _packet.dstEid,\\n            _packet.receiver,\\n            _packet.guid,\\n            _packet.message\\n        );\\n    }\\n\\n    function encodePacketHeader(Packet memory _packet) internal pure returns (bytes memory) {\\n        return\\n            abi.encodePacked(\\n                PACKET_VERSION,\\n                _packet.nonce,\\n                _packet.srcEid,\\n                _packet.sender.toBytes32(),\\n                _packet.dstEid,\\n                _packet.receiver\\n            );\\n    }\\n\\n    function encodePayload(Packet memory _packet) internal pure returns (bytes memory) {\\n        return abi.encodePacked(_packet.guid, _packet.message);\\n    }\\n\\n    function header(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return _packet[0:GUID_OFFSET];\\n    }\\n\\n    function version(bytes calldata _packet) internal pure returns (uint8) {\\n        return uint8(bytes1(_packet[PACKET_VERSION_OFFSET:NONCE_OFFSET]));\\n    }\\n\\n    function nonce(bytes calldata _packet) internal pure returns (uint64) {\\n        return uint64(bytes8(_packet[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    function srcEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[SRC_EID_OFFSET:SENDER_OFFSET]));\\n    }\\n\\n    function sender(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[SENDER_OFFSET:DST_EID_OFFSET]);\\n    }\\n\\n    function senderAddressB20(bytes calldata _packet) internal pure returns (address) {\\n        return sender(_packet).toAddress();\\n    }\\n\\n    function dstEid(bytes calldata _packet) internal pure returns (uint32) {\\n        return uint32(bytes4(_packet[DST_EID_OFFSET:RECEIVER_OFFSET]));\\n    }\\n\\n    function receiver(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[RECEIVER_OFFSET:GUID_OFFSET]);\\n    }\\n\\n    function receiverB20(bytes calldata _packet) internal pure returns (address) {\\n        return receiver(_packet).toAddress();\\n    }\\n\\n    function guid(bytes calldata _packet) internal pure returns (bytes32) {\\n        return bytes32(_packet[GUID_OFFSET:MESSAGE_OFFSET]);\\n    }\\n\\n    function message(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[MESSAGE_OFFSET:]);\\n    }\\n\\n    function payload(bytes calldata _packet) internal pure returns (bytes calldata) {\\n        return bytes(_packet[GUID_OFFSET:]);\\n    }\\n\\n    function payloadHash(bytes calldata _packet) internal pure returns (bytes32) {\\n        return keccak256(payload(_packet));\\n    }\\n}\\n\",\"keccak256\":\"0xc84cf1bf785977fe1fbe7566eef902c2db68d0e163813ebe6c34921754802680\",\"license\":\"LZBL-1.2\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the 'MessagingFee' and 'MessagingReceipt' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppSender, MessagingFee, MessagingReceipt } from \\\"./OAppSender.sol\\\";\\n// @dev Import the 'Origin' so it's exposed to OApp implementers\\n// solhint-disable-next-line no-unused-import\\nimport { OAppReceiver, Origin } from \\\"./OAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OApp\\n * @dev Abstract contract serving as the base for OApp implementation, combining OAppSender and OAppReceiver functionality.\\n */\\nabstract contract OApp is OAppSender, OAppReceiver {\\n    /**\\n     * @dev Constructor to initialize the OApp with the provided endpoint and owner.\\n     * @param _endpoint The address of the LOCAL LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(address _endpoint, address _delegate) OAppCore(_endpoint, _delegate) {}\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol implementation.\\n     * @return receiverVersion The version of the OAppReceiver.sol implementation.\\n     */\\n    function oAppVersion()\\n        public\\n        pure\\n        virtual\\n        override(OAppSender, OAppReceiver)\\n        returns (uint64 senderVersion, uint64 receiverVersion)\\n    {\\n        return (SENDER_VERSION, RECEIVER_VERSION);\\n    }\\n}\\n\",\"keccak256\":\"0xac362c4c291fad2f1511a968424b2e78a5ad502d1c867bd31da04be742aca8c5\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppCore, ILayerZeroEndpointV2 } from \\\"./interfaces/IOAppCore.sol\\\";\\n\\n/**\\n * @title OAppCore\\n * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations.\\n */\\nabstract contract OAppCore is IOAppCore, Ownable {\\n    // The LayerZero endpoint associated with the given OApp\\n    ILayerZeroEndpointV2 public immutable endpoint;\\n\\n    // Mapping to store peers associated with corresponding endpoints\\n    mapping(uint32 eid => bytes32 peer) public peers;\\n\\n    /**\\n     * @dev Constructor to initialize the OAppCore with the provided endpoint and delegate.\\n     * @param _endpoint The address of the LOCAL Layer Zero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     *\\n     * @dev The delegate typically should be set as the owner of the contract.\\n     */\\n    constructor(address _endpoint, address _delegate) {\\n        endpoint = ILayerZeroEndpointV2(_endpoint);\\n\\n        if (_delegate == address(0)) revert InvalidDelegate();\\n        endpoint.setDelegate(_delegate);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {\\n        _setPeer(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     *\\n     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.\\n     * @dev Set this to bytes32(0) to remove the peer address.\\n     * @dev Peer is a bytes32 to accommodate non-evm chains.\\n     */\\n    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {\\n        peers[_eid] = _peer;\\n        emit PeerSet(_eid, _peer);\\n    }\\n\\n    /**\\n     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.\\n     * ie. the peer is set to bytes32(0).\\n     * @param _eid The endpoint ID.\\n     * @return peer The address of the peer associated with the specified endpoint.\\n     */\\n    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {\\n        bytes32 peer = peers[_eid];\\n        if (peer == bytes32(0)) revert NoPeer(_eid);\\n        return peer;\\n    }\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp.\\n     * @param _delegate The address of the delegate to be set.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.\\n     */\\n    function setDelegate(address _delegate) public onlyOwner {\\n        endpoint.setDelegate(_delegate);\\n    }\\n}\\n\",\"keccak256\":\"0x13a9c2d1d2c1f086b8624f2e84c4a4702212daae36f701d92bb915b535cbe4cc\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IOAppReceiver, Origin } from \\\"./interfaces/IOAppReceiver.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppReceiver\\n * @dev Abstract contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp receivers.\\n */\\nabstract contract OAppReceiver is IOAppReceiver, OAppCore {\\n    // Custom error message for when the caller is not the registered endpoint/\\n    error OnlyEndpoint(address addr);\\n\\n    // @dev The version of the OAppReceiver implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant RECEIVER_VERSION = 2;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.\\n     * ie. this is a RECEIVE only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (0, RECEIVER_VERSION);\\n    }\\n\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @dev _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @dev _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata /*_origin*/,\\n        bytes calldata /*_message*/,\\n        address _sender\\n    ) public view virtual returns (bool) {\\n        return _sender == address(this);\\n    }\\n\\n    /**\\n     * @notice Checks if the path initialization is allowed based on the provided origin.\\n     * @param origin The origin information containing the source endpoint and sender address.\\n     * @return Whether the path has been initialized.\\n     *\\n     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.\\n     * @dev This defaults to assuming if a peer has been set, its initialized.\\n     * Can be overridden by the OApp if there is other logic to determine this.\\n     */\\n    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {\\n        return peers[origin.srcEid] == origin.sender;\\n    }\\n\\n    /**\\n     * @notice Retrieves the next nonce for a given source endpoint and sender address.\\n     * @dev _srcEid The source endpoint ID.\\n     * @dev _sender The sender address.\\n     * @return nonce The next nonce.\\n     *\\n     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.\\n     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.\\n     * @dev This is also enforced by the OApp.\\n     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.\\n     */\\n    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {\\n        return 0;\\n    }\\n\\n    /**\\n     * @dev Entry point for receiving messages or packets from the endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The payload of the received message.\\n     * @param _executor The address of the executor for the received message.\\n     * @param _extraData Additional arbitrary data provided by the corresponding executor.\\n     *\\n     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.\\n     */\\n    function lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) public payable virtual {\\n        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.\\n        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);\\n\\n        // Ensure that the sender matches the expected peer for the source endpoint.\\n        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);\\n\\n        // Call the internal OApp implementation of lzReceive.\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n}\\n\",\"keccak256\":\"0x0174e9f1ec4cefe4b5adc26c392269c699b9ff75965364e5b7264426a462c70b\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { SafeERC20, IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\\\";\\nimport { MessagingParams, MessagingFee, MessagingReceipt } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { OAppCore } from \\\"./OAppCore.sol\\\";\\n\\n/**\\n * @title OAppSender\\n * @dev Abstract contract implementing the OAppSender functionality for sending messages to a LayerZero endpoint.\\n */\\nabstract contract OAppSender is OAppCore {\\n    using SafeERC20 for IERC20;\\n\\n    // Custom error messages\\n    error NotEnoughNative(uint256 msgValue);\\n    error LzTokenUnavailable();\\n\\n    // @dev The version of the OAppSender implementation.\\n    // @dev Version is bumped when changes are made to this contract.\\n    uint64 internal constant SENDER_VERSION = 1;\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     *\\n     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.\\n     * ie. this is a SEND only OApp.\\n     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions\\n     */\\n    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {\\n        return (SENDER_VERSION, 0);\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.\\n     * @return fee The calculated MessagingFee for the message.\\n     *      - nativeFee: The native fee for the message.\\n     *      - lzTokenFee: The LZ token fee for the message.\\n     */\\n    function _quote(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        bool _payInLzToken\\n    ) internal view virtual returns (MessagingFee memory fee) {\\n        return\\n            endpoint.quote(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),\\n                address(this)\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.\\n     * @param _dstEid The destination endpoint ID.\\n     * @param _message The message payload.\\n     * @param _options Additional options for the message.\\n     * @param _fee The calculated LayerZero fee for the message.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.\\n     * @return receipt The receipt for the sent message.\\n     *      - guid: The unique identifier for the sent message.\\n     *      - nonce: The nonce of the sent message.\\n     *      - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _lzSend(\\n        uint32 _dstEid,\\n        bytes memory _message,\\n        bytes memory _options,\\n        MessagingFee memory _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory receipt) {\\n        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.\\n        uint256 messageValue = _payNative(_fee.nativeFee);\\n        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);\\n\\n        return\\n            // solhint-disable-next-line check-send-result\\n            endpoint.send{ value: messageValue }(\\n                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),\\n                _refundAddress\\n            );\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the native fee associated with the message.\\n     * @param _nativeFee The native fee to be paid.\\n     * @return nativeFee The amount of native currency paid.\\n     *\\n     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,\\n     * this will need to be overridden because msg.value would contain multiple lzFees.\\n     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.\\n     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.\\n     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.\\n     */\\n    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {\\n        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);\\n        return _nativeFee;\\n    }\\n\\n    /**\\n     * @dev Internal function to pay the LZ token fee associated with the message.\\n     * @param _lzTokenFee The LZ token fee to be paid.\\n     *\\n     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.\\n     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().\\n     */\\n    function _payLzToken(uint256 _lzTokenFee) internal virtual {\\n        // @dev Cannot cache the token because it is not immutable in the endpoint.\\n        address lzToken = endpoint.lzToken();\\n        if (lzToken == address(0)) revert LzTokenUnavailable();\\n\\n        // Pay LZ token fee by sending tokens to the endpoint.\\n        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);\\n    }\\n}\\n\",\"keccak256\":\"0x518cf4adca601923ed4baa6619846a253ea32b8d8775f8bc1faa3dfac7f67c20\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroEndpointV2 } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\n\\n/**\\n * @title IOAppCore\\n */\\ninterface IOAppCore {\\n    // Custom error messages\\n    error OnlyPeer(uint32 eid, bytes32 sender);\\n    error NoPeer(uint32 eid);\\n    error InvalidEndpointCall();\\n    error InvalidDelegate();\\n\\n    // Event emitted when a peer (OApp) is set for a corresponding endpoint\\n    event PeerSet(uint32 eid, bytes32 peer);\\n\\n    /**\\n     * @notice Retrieves the OApp version information.\\n     * @return senderVersion The version of the OAppSender.sol contract.\\n     * @return receiverVersion The version of the OAppReceiver.sol contract.\\n     */\\n    function oAppVersion() external view returns (uint64 senderVersion, uint64 receiverVersion);\\n\\n    /**\\n     * @notice Retrieves the LayerZero endpoint associated with the OApp.\\n     * @return iEndpoint The LayerZero endpoint as an interface.\\n     */\\n    function endpoint() external view returns (ILayerZeroEndpointV2 iEndpoint);\\n\\n    /**\\n     * @notice Retrieves the peer (OApp) associated with a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @return peer The peer address (OApp instance) associated with the corresponding endpoint.\\n     */\\n    function peers(uint32 _eid) external view returns (bytes32 peer);\\n\\n    /**\\n     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.\\n     * @param _eid The endpoint ID.\\n     * @param _peer The address of the peer to be associated with the corresponding endpoint.\\n     */\\n    function setPeer(uint32 _eid, bytes32 _peer) external;\\n\\n    /**\\n     * @notice Sets the delegate address for the OApp Core.\\n     * @param _delegate The address of the delegate to be set.\\n     */\\n    function setDelegate(address _delegate) external;\\n}\\n\",\"keccak256\":\"0x40e49f2de74506e1da5dcaed53a39853f691647f4ceb0fccc8f49a68d3f47c58\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @title IOAppMsgInspector\\n * @dev Interface for the OApp Message Inspector, allowing examination of message and options contents.\\n */\\ninterface IOAppMsgInspector {\\n    // Custom error message for inspection failure\\n    error InspectionFailed(bytes message, bytes options);\\n\\n    /**\\n     * @notice Allows the inspector to examine LayerZero message contents and optionally throw a revert if invalid.\\n     * @param _message The message payload to be inspected.\\n     * @param _options Additional options or parameters for inspection.\\n     * @return valid A boolean indicating whether the inspection passed (true) or failed (false).\\n     *\\n     * @dev Optionally done as a revert, OR use the boolean provided to handle the failure.\\n     */\\n    function inspect(bytes calldata _message, bytes calldata _options) external view returns (bool valid);\\n}\\n\",\"keccak256\":\"0x339654e699043c400cad92de209aa23855ce10211c31cf4114042cc5224d3b7c\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Struct representing enforced option parameters.\\n */\\nstruct EnforcedOptionParam {\\n    uint32 eid; // Endpoint ID\\n    uint16 msgType; // Message Type\\n    bytes options; // Additional options\\n}\\n\\n/**\\n * @title IOAppOptionsType3\\n * @dev Interface for the OApp with Type 3 Options, allowing the setting and combining of enforced options.\\n */\\ninterface IOAppOptionsType3 {\\n    // Custom error message for invalid options\\n    error InvalidOptions(bytes options);\\n\\n    // Event emitted when enforced options are set\\n    event EnforcedOptionSet(EnforcedOptionParam[] _enforcedOptions);\\n\\n    /**\\n     * @notice Sets enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) external;\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OApp message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) external view returns (bytes memory options);\\n}\\n\",\"keccak256\":\"0x9fc08a51e9d7c9c710c4eb26f84fe77228305ad7da63fa486ff24ebf2f3bc461\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppReceiver.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\npragma solidity ^0.8.20;\\n\\nimport { ILayerZeroReceiver, Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol\\\";\\n\\ninterface IOAppReceiver is ILayerZeroReceiver {\\n    /**\\n     * @notice Indicates whether an address is an approved composeMsg sender to the Endpoint.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _message The lzReceive payload.\\n     * @param _sender The sender address.\\n     * @return isSender Is a valid sender.\\n     *\\n     * @dev Applications can optionally choose to implement a separate composeMsg sender that is NOT the bridging layer.\\n     * @dev The default sender IS the OAppReceiver implementer.\\n     */\\n    function isComposeMsgSender(\\n        Origin calldata _origin,\\n        bytes calldata _message,\\n        address _sender\\n    ) external view returns (bool isSender);\\n}\\n\",\"keccak256\":\"0xd26135185e19b3732746d4a9e2923e896f28dec8664bab161faea2ee26fcdc3d\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IOAppOptionsType3, EnforcedOptionParam } from \\\"../interfaces/IOAppOptionsType3.sol\\\";\\n\\n/**\\n * @title OAppOptionsType3\\n * @dev Abstract contract implementing the IOAppOptionsType3 interface with type 3 options.\\n */\\nabstract contract OAppOptionsType3 is IOAppOptionsType3, Ownable {\\n    uint16 internal constant OPTION_TYPE_3 = 3;\\n\\n    // @dev The \\\"msgType\\\" should be defined in the child contract.\\n    mapping(uint32 eid => mapping(uint16 msgType => bytes enforcedOption)) public enforcedOptions;\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Only the owner/admin of the OApp can call this function.\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function setEnforcedOptions(EnforcedOptionParam[] calldata _enforcedOptions) public virtual onlyOwner {\\n        _setEnforcedOptions(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @dev Sets the enforced options for specific endpoint and message type combinations.\\n     * @param _enforcedOptions An array of EnforcedOptionParam structures specifying enforced options.\\n     *\\n     * @dev Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.\\n     * @dev These enforced options can vary as the potential options/execution on the remote may differ as per the msgType.\\n     * eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay\\n     * if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().\\n     */\\n    function _setEnforcedOptions(EnforcedOptionParam[] memory _enforcedOptions) internal virtual {\\n        for (uint256 i = 0; i < _enforcedOptions.length; i++) {\\n            // @dev Enforced options are only available for optionType 3, as type 1 and 2 dont support combining.\\n            _assertOptionsType3(_enforcedOptions[i].options);\\n            enforcedOptions[_enforcedOptions[i].eid][_enforcedOptions[i].msgType] = _enforcedOptions[i].options;\\n        }\\n\\n        emit EnforcedOptionSet(_enforcedOptions);\\n    }\\n\\n    /**\\n     * @notice Combines options for a given endpoint and message type.\\n     * @param _eid The endpoint ID.\\n     * @param _msgType The OAPP message type.\\n     * @param _extraOptions Additional options passed by the caller.\\n     * @return options The combination of caller specified options AND enforced options.\\n     *\\n     * @dev If there is an enforced lzReceive option:\\n     * - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether}\\n     * - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.\\n     * @dev This presence of duplicated options is handled off-chain in the verifier/executor.\\n     */\\n    function combineOptions(\\n        uint32 _eid,\\n        uint16 _msgType,\\n        bytes calldata _extraOptions\\n    ) public view virtual returns (bytes memory) {\\n        bytes memory enforced = enforcedOptions[_eid][_msgType];\\n\\n        // No enforced options, pass whatever the caller supplied, even if it's empty or legacy type 1/2 options.\\n        if (enforced.length == 0) return _extraOptions;\\n\\n        // No caller options, return enforced\\n        if (_extraOptions.length == 0) return enforced;\\n\\n        // @dev If caller provided _extraOptions, must be type 3 as its the ONLY type that can be combined.\\n        if (_extraOptions.length >= 2) {\\n            _assertOptionsType3(_extraOptions);\\n            // @dev Remove the first 2 bytes containing the type from the _extraOptions and combine with enforced.\\n            return bytes.concat(enforced, _extraOptions[2:]);\\n        }\\n\\n        // No valid set of options was found.\\n        revert InvalidOptions(_extraOptions);\\n    }\\n\\n    /**\\n     * @dev Internal function to assert that options are of type 3.\\n     * @param _options The options to be checked.\\n     */\\n    function _assertOptionsType3(bytes memory _options) internal pure virtual {\\n        uint16 optionsType;\\n        assembly {\\n            optionsType := mload(add(_options, 2))\\n        }\\n        if (optionsType != OPTION_TYPE_3) revert InvalidOptions(_options);\\n    }\\n}\\n\",\"keccak256\":\"0x5275636cd47e660a2fdf6c7fe9d41ff3cc866b785cc8a9d88c1b8ca983509f01\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { IPreCrime } from \\\"./interfaces/IPreCrime.sol\\\";\\nimport { IOAppPreCrimeSimulator, InboundPacket, Origin } from \\\"./interfaces/IOAppPreCrimeSimulator.sol\\\";\\n\\n/**\\n * @title OAppPreCrimeSimulator\\n * @dev Abstract contract serving as the base for preCrime simulation functionality in an OApp.\\n */\\nabstract contract OAppPreCrimeSimulator is IOAppPreCrimeSimulator, Ownable {\\n    // The address of the preCrime implementation.\\n    address public preCrime;\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     *\\n     * @dev The simulator contract is the base contract for the OApp by default.\\n     * @dev If the simulator is a separate contract, override this function.\\n     */\\n    function oApp() external view virtual returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) public virtual onlyOwner {\\n        preCrime = _preCrime;\\n        emit PreCrimeSet(_preCrime);\\n    }\\n\\n    /**\\n     * @dev Interface for pre-crime simulations. Always reverts at the end with the simulation results.\\n     * @param _packets An array of InboundPacket objects representing received packets to be delivered.\\n     *\\n     * @dev WARNING: MUST revert at the end with the simulation results.\\n     * @dev Gives the preCrime implementation the ability to mock sending packets to the lzReceive function,\\n     * WITHOUT actually executing them.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) public payable virtual {\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            InboundPacket calldata packet = _packets[i];\\n\\n            // Ignore packets that are not from trusted peers.\\n            if (!isPeer(packet.origin.srcEid, packet.origin.sender)) continue;\\n\\n            // @dev Because a verifier is calling this function, it doesnt have access to executor params:\\n            //  - address _executor\\n            //  - bytes calldata _extraData\\n            // preCrime will NOT work for OApps that rely on these two parameters inside of their _lzReceive().\\n            // They are instead stubbed to default values, address(0) and bytes(\\\"\\\")\\n            // @dev Calling this.lzReceiveSimulate removes ability for assembly return 0 callstack exit,\\n            // which would cause the revert to be ignored.\\n            this.lzReceiveSimulate{ value: packet.value }(\\n                packet.origin,\\n                packet.guid,\\n                packet.message,\\n                packet.executor,\\n                packet.extraData\\n            );\\n        }\\n\\n        // @dev Revert with the simulation results. msg.sender must implement IPreCrime.buildSimulationResult().\\n        revert SimulationResult(IPreCrime(msg.sender).buildSimulationResult());\\n    }\\n\\n    /**\\n     * @dev Is effectively an internal function because msg.sender must be address(this).\\n     * Allows resetting the call stack for 'internal' calls.\\n     * @param _origin The origin information containing the source endpoint and sender address.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address on the src chain.\\n     *  - nonce: The nonce of the message.\\n     * @param _guid The unique identifier of the packet.\\n     * @param _message The message payload of the packet.\\n     * @param _executor The executor address for the packet.\\n     * @param _extraData Additional data for the packet.\\n     */\\n    function lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) external payable virtual {\\n        // @dev Ensure ONLY can be called 'internally'.\\n        if (msg.sender != address(this)) revert OnlySelf();\\n        _lzReceiveSimulate(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The GUID of the LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual returns (bool);\\n}\\n\",\"keccak256\":\"0x205a0abfd8b3c9af2740769f251381b84999b8e9347f3cd50de3ef8290a17750\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IOAppPreCrimeSimulator.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\n// @dev Import the Origin so it's exposed to OAppPreCrimeSimulator implementers.\\n// solhint-disable-next-line no-unused-import\\nimport { InboundPacket, Origin } from \\\"../libs/Packet.sol\\\";\\n\\n/**\\n * @title IOAppPreCrimeSimulator Interface\\n * @dev Interface for the preCrime simulation functionality in an OApp.\\n */\\ninterface IOAppPreCrimeSimulator {\\n    // @dev simulation result used in PreCrime implementation\\n    error SimulationResult(bytes result);\\n    error OnlySelf();\\n\\n    /**\\n     * @dev Emitted when the preCrime contract address is set.\\n     * @param preCrimeAddress The address of the preCrime contract.\\n     */\\n    event PreCrimeSet(address preCrimeAddress);\\n\\n    /**\\n     * @dev Retrieves the address of the preCrime contract implementation.\\n     * @return The address of the preCrime contract.\\n     */\\n    function preCrime() external view returns (address);\\n\\n    /**\\n     * @dev Retrieves the address of the OApp contract.\\n     * @return The address of the OApp contract.\\n     */\\n    function oApp() external view returns (address);\\n\\n    /**\\n     * @dev Sets the preCrime contract address.\\n     * @param _preCrime The address of the preCrime contract.\\n     */\\n    function setPreCrime(address _preCrime) external;\\n\\n    /**\\n     * @dev Mocks receiving a packet, then reverts with a series of data to infer the state/result.\\n     * @param _packets An array of LayerZero InboundPacket objects representing received packets.\\n     */\\n    function lzReceiveAndRevert(InboundPacket[] calldata _packets) external payable;\\n\\n    /**\\n     * @dev checks if the specified peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint Id to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x5d24db150949ea8e6437178e65a942e8c8b7f332e5daf32750f56b23b35b5bb2\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/interfaces/IPreCrime.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\nstruct PreCrimePeer {\\n    uint32 eid;\\n    bytes32 preCrime;\\n    bytes32 oApp;\\n}\\n\\n// TODO not done yet\\ninterface IPreCrime {\\n    error OnlyOffChain();\\n\\n    // for simulate()\\n    error PacketOversize(uint256 max, uint256 actual);\\n    error PacketUnsorted();\\n    error SimulationFailed(bytes reason);\\n\\n    // for preCrime()\\n    error SimulationResultNotFound(uint32 eid);\\n    error InvalidSimulationResult(uint32 eid, bytes reason);\\n    error CrimeFound(bytes crime);\\n\\n    function getConfig(bytes[] calldata _packets, uint256[] calldata _packetMsgValues) external returns (bytes memory);\\n\\n    function simulate(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues\\n    ) external payable returns (bytes memory);\\n\\n    function buildSimulationResult() external view returns (bytes memory);\\n\\n    function preCrime(\\n        bytes[] calldata _packets,\\n        uint256[] calldata _packetMsgValues,\\n        bytes[] calldata _simulations\\n    ) external;\\n\\n    function version() external view returns (uint64 major, uint8 minor);\\n}\\n\",\"keccak256\":\"0xc8d869f27ef8ceb2e13fdf6a70682fd4dee3f90c4924eb8e125bc1e66cb6af84\",\"license\":\"MIT\"},\"@layerzerolabs/oapp-evm/contracts/precrime/libs/Packet.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { Origin } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol\\\";\\nimport { PacketV1Codec } from \\\"@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol\\\";\\n\\n/**\\n * @title InboundPacket\\n * @dev Structure representing an inbound packet received by the contract.\\n */\\nstruct InboundPacket {\\n    Origin origin; // Origin information of the packet.\\n    uint32 dstEid; // Destination endpointId of the packet.\\n    address receiver; // Receiver address for the packet.\\n    bytes32 guid; // Unique identifier of the packet.\\n    uint256 value; // msg.value of the packet.\\n    address executor; // Executor address for the packet.\\n    bytes message; // Message payload of the packet.\\n    bytes extraData; // Additional arbitrary data for the packet.\\n}\\n\\n/**\\n * @title PacketDecoder\\n * @dev Library for decoding LayerZero packets.\\n */\\nlibrary PacketDecoder {\\n    using PacketV1Codec for bytes;\\n\\n    /**\\n     * @dev Decode an inbound packet from the given packet data.\\n     * @param _packet The packet data to decode.\\n     * @return packet An InboundPacket struct representing the decoded packet.\\n     */\\n    function decode(bytes calldata _packet) internal pure returns (InboundPacket memory packet) {\\n        packet.origin = Origin(_packet.srcEid(), _packet.sender(), _packet.nonce());\\n        packet.dstEid = _packet.dstEid();\\n        packet.receiver = _packet.receiverB20();\\n        packet.guid = _packet.guid();\\n        packet.message = _packet.message();\\n    }\\n\\n    /**\\n     * @dev Decode multiple inbound packets from the given packet data and associated message values.\\n     * @param _packets An array of packet data to decode.\\n     * @param _packetMsgValues An array of associated message values for each packet.\\n     * @return packets An array of InboundPacket structs representing the decoded packets.\\n     */\\n    function decode(\\n        bytes[] calldata _packets,\\n        uint256[] memory _packetMsgValues\\n    ) internal pure returns (InboundPacket[] memory packets) {\\n        packets = new InboundPacket[](_packets.length);\\n        for (uint256 i = 0; i < _packets.length; i++) {\\n            bytes calldata packet = _packets[i];\\n            packets[i] = PacketDecoder.decode(packet);\\n            // @dev Allows the verifier to specify the msg.value that gets passed in lzReceive.\\n            packets[i].value = _packetMsgValues[i];\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcb2fb1c5b2eb3731de78b479b9c2ab3bba326fe0b0b3a008590f18e881e457a6\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { ERC20 } from \\\"@openzeppelin/contracts/token/ERC20/ERC20.sol\\\";\\nimport { IOFT, OFTCore } from \\\"./OFTCore.sol\\\";\\n\\n/**\\n * @title OFT Contract\\n * @dev OFT is an ERC-20 token that extends the functionality of the OFTCore contract.\\n */\\nabstract contract OFT is OFTCore, ERC20 {\\n    /**\\n     * @dev Constructor for the OFT contract.\\n     * @param _name The name of the OFT.\\n     * @param _symbol The symbol of the OFT.\\n     * @param _lzEndpoint The LayerZero endpoint address.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) ERC20(_name, _symbol) OFTCore(decimals(), _lzEndpoint, _delegate) {}\\n\\n    /**\\n     * @dev Retrieves the address of the underlying ERC20 implementation.\\n     * @return The address of the OFT token.\\n     *\\n     * @dev In the case of OFT, address(this) and erc20 are the same contract.\\n     */\\n    function token() public view returns (address) {\\n        return address(this);\\n    }\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev In the case of OFT where the contract IS the token, approval is NOT required.\\n     */\\n    function approvalRequired() external pure virtual returns (bool) {\\n        return false;\\n    }\\n\\n    /**\\n     * @dev Burns tokens from the sender's specified balance.\\n     * @param _from The address to debit the tokens from.\\n     * @param _amountLD The amount of tokens to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination chain ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);\\n\\n        // @dev In NON-default OFT, amountSentLD could be 100, with a 10% fee, the amountReceivedLD amount is 90,\\n        // therefore amountSentLD CAN differ from amountReceivedLD.\\n\\n        // @dev Default OFT burns on src.\\n        _burn(_from, amountSentLD);\\n    }\\n\\n    /**\\n     * @dev Credits tokens to the specified address.\\n     * @param _to The address to credit the tokens to.\\n     * @param _amountLD The amount of tokens to credit in local decimals.\\n     * @dev _srcEid The source chain ID.\\n     * @return amountReceivedLD The amount of tokens ACTUALLY received in local decimals.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 /*_srcEid*/\\n    ) internal virtual override returns (uint256 amountReceivedLD) {\\n        if (_to == address(0x0)) _to = address(0xdead); // _mint(...) does not support address(0x0)\\n        // @dev Default OFT mints on dst.\\n        _mint(_to, _amountLD);\\n        // @dev In the case of NON-default OFT, the _amountLD MIGHT not be == amountReceivedLD.\\n        return _amountLD;\\n    }\\n}\\n\",\"keccak256\":\"0xdc3582e4a20e02a79050c17058a1f1f42a4335d1a70be06c0a52a3fb05d4c89a\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/OFTCore.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { IERC20 } from \\\"@openzeppelin/contracts/token/ERC20/IERC20.sol\\\";\\n\\nimport { OApp, Origin } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OApp.sol\\\";\\nimport { OAppOptionsType3 } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/libs/OAppOptionsType3.sol\\\";\\nimport { IOAppMsgInspector } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/interfaces/IOAppMsgInspector.sol\\\";\\n\\nimport { OAppPreCrimeSimulator } from \\\"@layerzerolabs/oapp-evm/contracts/precrime/OAppPreCrimeSimulator.sol\\\";\\n\\nimport { IOFT, SendParam, OFTLimit, OFTReceipt, OFTFeeDetail, MessagingReceipt, MessagingFee } from \\\"./interfaces/IOFT.sol\\\";\\nimport { OFTMsgCodec } from \\\"./libs/OFTMsgCodec.sol\\\";\\nimport { OFTComposeMsgCodec } from \\\"./libs/OFTComposeMsgCodec.sol\\\";\\n\\n/**\\n * @title OFTCore\\n * @dev Abstract contract for the OftChain (OFT) token.\\n */\\nabstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3 {\\n    using OFTMsgCodec for bytes;\\n    using OFTMsgCodec for bytes32;\\n\\n    // @notice Provides a conversion rate when swapping between denominations of SD and LD\\n    //      - shareDecimals == SD == shared Decimals\\n    //      - localDecimals == LD == local decimals\\n    // @dev Considers that tokens have different decimal amounts on various chains.\\n    // @dev eg.\\n    //  For a token\\n    //      - locally with 4 decimals --> 1.2345 => uint(12345)\\n    //      - remotely with 2 decimals --> 1.23 => uint(123)\\n    //      - The conversion rate would be 10 ** (4 - 2) = 100\\n    //  @dev If you want to send 1.2345 -> (uint 12345), you CANNOT represent that value on the remote,\\n    //  you can only display 1.23 -> uint(123).\\n    //  @dev To preserve the dust that would otherwise be lost on that conversion,\\n    //  we need to unify a denomination that can be represented on ALL chains inside of the OFT mesh\\n    uint256 public immutable decimalConversionRate;\\n\\n    // @notice Msg types that are used to identify the various OFT operations.\\n    // @dev This can be extended in child contracts for non-default oft operations\\n    // @dev These values are used in things like combineOptions() in OAppOptionsType3.sol.\\n    uint16 public constant SEND = 1;\\n    uint16 public constant SEND_AND_CALL = 2;\\n\\n    // Address of an optional contract to inspect both 'message' and 'options'\\n    address public msgInspector;\\n    event MsgInspectorSet(address inspector);\\n\\n    /**\\n     * @dev Constructor.\\n     * @param _localDecimals The decimals of the token on the local chain (this chain).\\n     * @param _endpoint The address of the LayerZero endpoint.\\n     * @param _delegate The delegate capable of making OApp configurations inside of the endpoint.\\n     */\\n    constructor(uint8 _localDecimals, address _endpoint, address _delegate) OApp(_endpoint, _delegate) {\\n        if (_localDecimals < sharedDecimals()) revert InvalidLocalDecimals();\\n        decimalConversionRate = 10 ** (_localDecimals - sharedDecimals());\\n    }\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external pure virtual returns (bytes4 interfaceId, uint64 version) {\\n        return (type(IOFT).interfaceId, 1);\\n    }\\n\\n    /**\\n     * @dev Retrieves the shared decimals of the OFT.\\n     * @return The shared decimals of the OFT.\\n     *\\n     * @dev Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap\\n     * Lowest common decimal denominator between chains.\\n     * Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64).\\n     * For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller.\\n     * ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615\\n     */\\n    function sharedDecimals() public view virtual returns (uint8) {\\n        return 6;\\n    }\\n\\n    /**\\n     * @dev Sets the message inspector address for the OFT.\\n     * @param _msgInspector The address of the message inspector.\\n     *\\n     * @dev This is an optional contract that can be used to inspect both 'message' and 'options'.\\n     * @dev Set it to address(0) to disable it, or set it to a contract address to enable it.\\n     */\\n    function setMsgInspector(address _msgInspector) public virtual onlyOwner {\\n        msgInspector = _msgInspector;\\n        emit MsgInspectorSet(_msgInspector);\\n    }\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return oftLimit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return oftReceipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    )\\n        external\\n        view\\n        virtual\\n        returns (OFTLimit memory oftLimit, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory oftReceipt)\\n    {\\n        uint256 minAmountLD = 0; // Unused in the default implementation.\\n        uint256 maxAmountLD = IERC20(this.token()).totalSupply(); // Unused in the default implementation.\\n        oftLimit = OFTLimit(minAmountLD, maxAmountLD);\\n\\n        // Unused in the default implementation; reserved for future complex fee details.\\n        oftFeeDetails = new OFTFeeDetail[](0);\\n\\n        // @dev This is the same as the send() operation, but without the actual send.\\n        // - amountSentLD is the amount in local decimals that would be sent from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.\\n        // @dev The amountSentLD MIGHT not equal the amount the user actually receives. HOWEVER, the default does.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debitView(\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return msgFee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(\\n        SendParam calldata _sendParam,\\n        bool _payInLzToken\\n    ) external view virtual returns (MessagingFee memory msgFee) {\\n        // @dev mock the amount to receive, this is the same operation used in the send().\\n        // The quote is as similar as possible to the actual send() operation.\\n        (, uint256 amountReceivedLD) = _debitView(_sendParam.amountLD, _sendParam.minAmountLD, _sendParam.dstEid);\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Calculates the LayerZero fee for the send() operation.\\n        return _quote(_sendParam.dstEid, message, options, _payInLzToken);\\n    }\\n\\n    /**\\n     * @dev Executes the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        return _send(_sendParam, _fee, _refundAddress);\\n    }\\n\\n    /**\\n     * @dev Internal function to execute the send operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The calculated fee for the send() operation.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds.\\n     * @return msgReceipt The receipt for the send operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function _send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) internal virtual returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {\\n        // @dev Applies the token transfers regarding this send() operation.\\n        // - amountSentLD is the amount in local decimals that was ACTUALLY sent/debited from the sender.\\n        // - amountReceivedLD is the amount in local decimals that will be received/credited to the recipient on the remote OFT instance.\\n        (uint256 amountSentLD, uint256 amountReceivedLD) = _debit(\\n            msg.sender,\\n            _sendParam.amountLD,\\n            _sendParam.minAmountLD,\\n            _sendParam.dstEid\\n        );\\n\\n        // @dev Builds the options and OFT message to quote in the endpoint.\\n        (bytes memory message, bytes memory options) = _buildMsgAndOptions(_sendParam, amountReceivedLD);\\n\\n        // @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.\\n        msgReceipt = _lzSend(_sendParam.dstEid, message, options, _fee, _refundAddress);\\n        // @dev Formulate the OFT receipt.\\n        oftReceipt = OFTReceipt(amountSentLD, amountReceivedLD);\\n\\n        emit OFTSent(msgReceipt.guid, _sendParam.dstEid, msg.sender, amountSentLD, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to build the message and options.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _amountLD The amount in local decimals.\\n     * @return message The encoded message.\\n     * @return options The encoded options.\\n     */\\n    function _buildMsgAndOptions(\\n        SendParam calldata _sendParam,\\n        uint256 _amountLD\\n    ) internal view virtual returns (bytes memory message, bytes memory options) {\\n        bool hasCompose;\\n        // @dev This generated message has the msg.sender encoded into the payload so the remote knows who the caller is.\\n        (message, hasCompose) = OFTMsgCodec.encode(\\n            _sendParam.to,\\n            _toSD(_amountLD),\\n            // @dev Must be include a non empty bytes if you want to compose, EVEN if you dont need it on the remote.\\n            // EVEN if you dont require an arbitrary payload to be sent... eg. '0x01'\\n            _sendParam.composeMsg\\n        );\\n        // @dev Change the msg type depending if its composed or not.\\n        uint16 msgType = hasCompose ? SEND_AND_CALL : SEND;\\n        // @dev Combine the callers _extraOptions with the enforced options via the OAppOptionsType3.\\n        options = combineOptions(_sendParam.dstEid, msgType, _sendParam.extraOptions);\\n\\n        // @dev Optionally inspect the message and options depending if the OApp owner has set a msg inspector.\\n        // @dev If it fails inspection, needs to revert in the implementation. ie. does not rely on return boolean\\n        address inspector = msgInspector; // caches the msgInspector to avoid potential double storage read\\n        if (inspector != address(0)) IOAppMsgInspector(inspector).inspect(message, options);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the receive on the LayerZero endpoint.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The encoded message.\\n     * @dev _executor The address of the executor.\\n     * @dev _extraData Additional data.\\n     */\\n    function _lzReceive(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address /*_executor*/, // @dev unused in the default implementation.\\n        bytes calldata /*_extraData*/ // @dev unused in the default implementation.\\n    ) internal virtual override {\\n        // @dev The src sending chain doesnt know the address length on this chain (potentially non-evm)\\n        // Thus everything is bytes32() encoded in flight.\\n        address toAddress = _message.sendTo().bytes32ToAddress();\\n        // @dev Credit the amountLD to the recipient and return the ACTUAL amount the recipient received in local decimals\\n        uint256 amountReceivedLD = _credit(toAddress, _toLD(_message.amountSD()), _origin.srcEid);\\n\\n        if (_message.isComposed()) {\\n            // @dev Proprietary composeMsg format for the OFT.\\n            bytes memory composeMsg = OFTComposeMsgCodec.encode(\\n                _origin.nonce,\\n                _origin.srcEid,\\n                amountReceivedLD,\\n                _message.composeMsg()\\n            );\\n\\n            // @dev Stores the lzCompose payload that will be executed in a separate tx.\\n            // Standardizes functionality for executing arbitrary contract invocation on some non-evm chains.\\n            // @dev The off-chain executor will listen and process the msg based on the src-chain-callers compose options passed.\\n            // @dev The index is used when a OApp needs to compose multiple msgs on lzReceive.\\n            // For default OFT implementation there is only 1 compose msg per lzReceive, thus its always 0.\\n            endpoint.sendCompose(toAddress, _guid, 0 /* the index of the composed message*/, composeMsg);\\n        }\\n\\n        emit OFTReceived(_guid, _origin.srcEid, toAddress, amountReceivedLD);\\n    }\\n\\n    /**\\n     * @dev Internal function to handle the OAppPreCrimeSimulator simulated receive.\\n     * @param _origin The origin information.\\n     *  - srcEid: The source chain endpoint ID.\\n     *  - sender: The sender address from the src chain.\\n     *  - nonce: The nonce of the LayerZero message.\\n     * @param _guid The unique identifier for the received LayerZero message.\\n     * @param _message The LayerZero message.\\n     * @param _executor The address of the off-chain executor.\\n     * @param _extraData Arbitrary data passed by the msg executor.\\n     *\\n     * @dev Enables the preCrime simulator to mock sending lzReceive() messages,\\n     * routes the msg down from the OAppPreCrimeSimulator, and back up to the OAppReceiver.\\n     */\\n    function _lzReceiveSimulate(\\n        Origin calldata _origin,\\n        bytes32 _guid,\\n        bytes calldata _message,\\n        address _executor,\\n        bytes calldata _extraData\\n    ) internal virtual override {\\n        _lzReceive(_origin, _guid, _message, _executor, _extraData);\\n    }\\n\\n    /**\\n     * @dev Check if the peer is considered 'trusted' by the OApp.\\n     * @param _eid The endpoint ID to check.\\n     * @param _peer The peer to check.\\n     * @return Whether the peer passed is considered 'trusted' by the OApp.\\n     *\\n     * @dev Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.\\n     */\\n    function isPeer(uint32 _eid, bytes32 _peer) public view virtual override returns (bool) {\\n        return peers[_eid] == _peer;\\n    }\\n\\n    /**\\n     * @dev Internal function to remove dust from the given local decimal amount.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountLD The amount after removing dust.\\n     *\\n     * @dev Prevents the loss of dust when moving amounts between chains with different decimals.\\n     * @dev eg. uint(123) with a conversion rate of 100 becomes uint(100).\\n     */\\n    function _removeDust(uint256 _amountLD) internal view virtual returns (uint256 amountLD) {\\n        return (_amountLD / decimalConversionRate) * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from shared decimals into local decimals.\\n     * @param _amountSD The amount in shared decimals.\\n     * @return amountLD The amount in local decimals.\\n     */\\n    function _toLD(uint64 _amountSD) internal view virtual returns (uint256 amountLD) {\\n        return _amountSD * decimalConversionRate;\\n    }\\n\\n    /**\\n     * @dev Internal function to convert an amount from local decimals into shared decimals.\\n     * @param _amountLD The amount in local decimals.\\n     * @return amountSD The amount in shared decimals.\\n     */\\n    function _toSD(uint256 _amountLD) internal view virtual returns (uint64 amountSD) {\\n        return uint64(_amountLD / decimalConversionRate);\\n    }\\n\\n    /**\\n     * @dev Internal function to mock the amount mutation from a OFT debit() operation.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @dev _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent, in local decimals.\\n     * @return amountReceivedLD The amount to be received on the remote chain, in local decimals.\\n     *\\n     * @dev This is where things like fees would be calculated and deducted from the amount to be received on the remote.\\n     */\\n    function _debitView(\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 /*_dstEid*/\\n    ) internal view virtual returns (uint256 amountSentLD, uint256 amountReceivedLD) {\\n        // @dev Remove the dust so nothing is lost on the conversion between chains with different decimals for the token.\\n        amountSentLD = _removeDust(_amountLD);\\n        // @dev The amount to send is the same as amount received in the default implementation.\\n        amountReceivedLD = amountSentLD;\\n\\n        // @dev Check for slippage.\\n        if (amountReceivedLD < _minAmountLD) {\\n            revert SlippageExceeded(amountReceivedLD, _minAmountLD);\\n        }\\n    }\\n\\n    /**\\n     * @dev Internal function to perform a debit operation.\\n     * @param _from The address to debit.\\n     * @param _amountLD The amount to send in local decimals.\\n     * @param _minAmountLD The minimum amount to send in local decimals.\\n     * @param _dstEid The destination endpoint ID.\\n     * @return amountSentLD The amount sent in local decimals.\\n     * @return amountReceivedLD The amount received in local decimals on the remote.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _debit(\\n        address _from,\\n        uint256 _amountLD,\\n        uint256 _minAmountLD,\\n        uint32 _dstEid\\n    ) internal virtual returns (uint256 amountSentLD, uint256 amountReceivedLD);\\n\\n    /**\\n     * @dev Internal function to perform a credit operation.\\n     * @param _to The address to credit.\\n     * @param _amountLD The amount to credit in local decimals.\\n     * @param _srcEid The source endpoint ID.\\n     * @return amountReceivedLD The amount ACTUALLY received in local decimals.\\n     *\\n     * @dev Defined here but are intended to be overriden depending on the OFT implementation.\\n     * @dev Depending on OFT implementation the _amountLD could differ from the amountReceivedLD.\\n     */\\n    function _credit(\\n        address _to,\\n        uint256 _amountLD,\\n        uint32 _srcEid\\n    ) internal virtual returns (uint256 amountReceivedLD);\\n}\\n\",\"keccak256\":\"0x4c5a5412cf671bb70d84c9e783312eddf864ef56566f7bf86401c5661015e228\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/interfaces/IOFT.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nimport { MessagingReceipt, MessagingFee } from \\\"@layerzerolabs/oapp-evm/contracts/oapp/OAppSender.sol\\\";\\n\\n/**\\n * @dev Struct representing token parameters for the OFT send() operation.\\n */\\nstruct SendParam {\\n    uint32 dstEid; // Destination endpoint ID.\\n    bytes32 to; // Recipient address.\\n    uint256 amountLD; // Amount to send in local decimals.\\n    uint256 minAmountLD; // Minimum amount to send in local decimals.\\n    bytes extraOptions; // Additional options supplied by the caller to be used in the LayerZero message.\\n    bytes composeMsg; // The composed message for the send() operation.\\n    bytes oftCmd; // The OFT command to be executed, unused in default OFT implementations.\\n}\\n\\n/**\\n * @dev Struct representing OFT limit information.\\n * @dev These amounts can change dynamically and are up the specific oft implementation.\\n */\\nstruct OFTLimit {\\n    uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.\\n    uint256 maxAmountLD; // Maximum amount in local decimals that can be sent to the recipient.\\n}\\n\\n/**\\n * @dev Struct representing OFT receipt information.\\n */\\nstruct OFTReceipt {\\n    uint256 amountSentLD; // Amount of tokens ACTUALLY debited from the sender in local decimals.\\n    // @dev In non-default implementations, the amountReceivedLD COULD differ from this value.\\n    uint256 amountReceivedLD; // Amount of tokens to be received on the remote side.\\n}\\n\\n/**\\n * @dev Struct representing OFT fee details.\\n * @dev Future proof mechanism to provide a standardized way to communicate fees to things like a UI.\\n */\\nstruct OFTFeeDetail {\\n    int256 feeAmountLD; // Amount of the fee in local decimals.\\n    string description; // Description of the fee.\\n}\\n\\n/**\\n * @title IOFT\\n * @dev Interface for the OftChain (OFT) token.\\n * @dev Does not inherit ERC20 to accommodate usage by OFTAdapter as well.\\n * @dev This specific interface ID is '0x02e49c2c'.\\n */\\ninterface IOFT {\\n    // Custom error messages\\n    error InvalidLocalDecimals();\\n    error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);\\n\\n    // Events\\n    event OFTSent(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 dstEid, // Destination Endpoint ID.\\n        address indexed fromAddress, // Address of the sender on the src chain.\\n        uint256 amountSentLD, // Amount of tokens sent in local decimals.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n    event OFTReceived(\\n        bytes32 indexed guid, // GUID of the OFT message.\\n        uint32 srcEid, // Source Endpoint ID.\\n        address indexed toAddress, // Address of the recipient on the dst chain.\\n        uint256 amountReceivedLD // Amount of tokens received in local decimals.\\n    );\\n\\n    /**\\n     * @notice Retrieves interfaceID and the version of the OFT.\\n     * @return interfaceId The interface ID.\\n     * @return version The version.\\n     *\\n     * @dev interfaceId: This specific interface ID is '0x02e49c2c'.\\n     * @dev version: Indicates a cross-chain compatible msg encoding with other OFTs.\\n     * @dev If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented.\\n     * ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)\\n     */\\n    function oftVersion() external view returns (bytes4 interfaceId, uint64 version);\\n\\n    /**\\n     * @notice Retrieves the address of the token associated with the OFT.\\n     * @return token The address of the ERC20 token implementation.\\n     */\\n    function token() external view returns (address);\\n\\n    /**\\n     * @notice Indicates whether the OFT contract requires approval of the 'token()' to send.\\n     * @return requiresApproval Needs approval of the underlying token implementation.\\n     *\\n     * @dev Allows things like wallet implementers to determine integration requirements,\\n     * without understanding the underlying token implementation.\\n     */\\n    function approvalRequired() external view returns (bool);\\n\\n    /**\\n     * @notice Retrieves the shared decimals of the OFT.\\n     * @return sharedDecimals The shared decimals of the OFT.\\n     */\\n    function sharedDecimals() external view returns (uint8);\\n\\n    /**\\n     * @notice Provides the fee breakdown and settings data for an OFT. Unused in the default implementation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @return limit The OFT limit information.\\n     * @return oftFeeDetails The details of OFT fees.\\n     * @return receipt The OFT receipt information.\\n     */\\n    function quoteOFT(\\n        SendParam calldata _sendParam\\n    ) external view returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);\\n\\n    /**\\n     * @notice Provides a quote for the send() operation.\\n     * @param _sendParam The parameters for the send() operation.\\n     * @param _payInLzToken Flag indicating whether the caller is paying in the LZ token.\\n     * @return fee The calculated LayerZero messaging fee from the send() operation.\\n     *\\n     * @dev MessagingFee: LayerZero msg fee\\n     *  - nativeFee: The native fee.\\n     *  - lzTokenFee: The lzToken fee.\\n     */\\n    function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);\\n\\n    /**\\n     * @notice Executes the send() operation.\\n     * @param _sendParam The parameters for the send operation.\\n     * @param _fee The fee information supplied by the caller.\\n     *      - nativeFee: The native fee.\\n     *      - lzTokenFee: The lzToken fee.\\n     * @param _refundAddress The address to receive any excess funds from fees etc. on the src.\\n     * @return receipt The LayerZero messaging receipt from the send() operation.\\n     * @return oftReceipt The OFT receipt information.\\n     *\\n     * @dev MessagingReceipt: LayerZero msg receipt\\n     *  - guid: The unique identifier for the sent message.\\n     *  - nonce: The nonce of the sent message.\\n     *  - fee: The LayerZero fee incurred for the message.\\n     */\\n    function send(\\n        SendParam calldata _sendParam,\\n        MessagingFee calldata _fee,\\n        address _refundAddress\\n    ) external payable returns (MessagingReceipt memory, OFTReceipt memory);\\n}\\n\",\"keccak256\":\"0x7ba6bb62fba7ee83451cfb0e727ddeef0e96b4388bd4e9ff0fc6ce103e1101c8\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTComposeMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTComposeMsgCodec {\\n    // Offset constants for decoding composed messages\\n    uint8 private constant NONCE_OFFSET = 8;\\n    uint8 private constant SRC_EID_OFFSET = 12;\\n    uint8 private constant AMOUNT_LD_OFFSET = 44;\\n    uint8 private constant COMPOSE_FROM_OFFSET = 76;\\n\\n    /**\\n     * @dev Encodes a OFT composed message.\\n     * @param _nonce The nonce value.\\n     * @param _srcEid The source endpoint ID.\\n     * @param _amountLD The amount in local decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded Composed message.\\n     */\\n    function encode(\\n        uint64 _nonce,\\n        uint32 _srcEid,\\n        uint256 _amountLD,\\n        bytes memory _composeMsg // 0x[composeFrom][composeMsg]\\n    ) internal pure returns (bytes memory _msg) {\\n        _msg = abi.encodePacked(_nonce, _srcEid, _amountLD, _composeMsg);\\n    }\\n\\n    /**\\n     * @dev Retrieves the nonce for the composed message.\\n     * @param _msg The message.\\n     * @return The nonce value.\\n     */\\n    function nonce(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[:NONCE_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the source endpoint ID for the composed message.\\n     * @param _msg The message.\\n     * @return The source endpoint ID.\\n     */\\n    function srcEid(bytes calldata _msg) internal pure returns (uint32) {\\n        return uint32(bytes4(_msg[NONCE_OFFSET:SRC_EID_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in local decimals from the composed message.\\n     * @param _msg The message.\\n     * @return The amount in local decimals.\\n     */\\n    function amountLD(bytes calldata _msg) internal pure returns (uint256) {\\n        return uint256(bytes32(_msg[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composeFrom value from the composed message.\\n     * @param _msg The message.\\n     * @return The composeFrom value.\\n     */\\n    function composeFrom(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[AMOUNT_LD_OFFSET:COMPOSE_FROM_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message.\\n     * @param _msg The message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[COMPOSE_FROM_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0xaae73d6eb8b9561c43f1802f3c416c00ccd35f172b711f9781ccdf1b25a40db5\",\"license\":\"MIT\"},\"@layerzerolabs/oft-evm/contracts/libs/OFTMsgCodec.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n\\npragma solidity ^0.8.20;\\n\\nlibrary OFTMsgCodec {\\n    // Offset constants for encoding and decoding OFT messages\\n    uint8 private constant SEND_TO_OFFSET = 32;\\n    uint8 private constant SEND_AMOUNT_SD_OFFSET = 40;\\n\\n    /**\\n     * @dev Encodes an OFT LayerZero message.\\n     * @param _sendTo The recipient address.\\n     * @param _amountShared The amount in shared decimals.\\n     * @param _composeMsg The composed message.\\n     * @return _msg The encoded message.\\n     * @return hasCompose A boolean indicating whether the message has a composed payload.\\n     */\\n    function encode(\\n        bytes32 _sendTo,\\n        uint64 _amountShared,\\n        bytes memory _composeMsg\\n    ) internal view returns (bytes memory _msg, bool hasCompose) {\\n        hasCompose = _composeMsg.length > 0;\\n        // @dev Remote chains will want to know the composed function caller ie. msg.sender on the src.\\n        _msg = hasCompose\\n            ? abi.encodePacked(_sendTo, _amountShared, addressToBytes32(msg.sender), _composeMsg)\\n            : abi.encodePacked(_sendTo, _amountShared);\\n    }\\n\\n    /**\\n     * @dev Checks if the OFT message is composed.\\n     * @param _msg The OFT message.\\n     * @return A boolean indicating whether the message is composed.\\n     */\\n    function isComposed(bytes calldata _msg) internal pure returns (bool) {\\n        return _msg.length > SEND_AMOUNT_SD_OFFSET;\\n    }\\n\\n    /**\\n     * @dev Retrieves the recipient address from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The recipient address.\\n     */\\n    function sendTo(bytes calldata _msg) internal pure returns (bytes32) {\\n        return bytes32(_msg[:SEND_TO_OFFSET]);\\n    }\\n\\n    /**\\n     * @dev Retrieves the amount in shared decimals from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The amount in shared decimals.\\n     */\\n    function amountSD(bytes calldata _msg) internal pure returns (uint64) {\\n        return uint64(bytes8(_msg[SEND_TO_OFFSET:SEND_AMOUNT_SD_OFFSET]));\\n    }\\n\\n    /**\\n     * @dev Retrieves the composed message from the OFT message.\\n     * @param _msg The OFT message.\\n     * @return The composed message.\\n     */\\n    function composeMsg(bytes calldata _msg) internal pure returns (bytes memory) {\\n        return _msg[SEND_AMOUNT_SD_OFFSET:];\\n    }\\n\\n    /**\\n     * @dev Converts an address to bytes32.\\n     * @param _addr The address to convert.\\n     * @return The bytes32 representation of the address.\\n     */\\n    function addressToBytes32(address _addr) internal pure returns (bytes32) {\\n        return bytes32(uint256(uint160(_addr)));\\n    }\\n\\n    /**\\n     * @dev Converts bytes32 to an address.\\n     * @param _b The bytes32 value to convert.\\n     * @return The address representation of bytes32.\\n     */\\n    function bytes32ToAddress(bytes32 _b) internal pure returns (address) {\\n        return address(uint160(uint256(_b)));\\n    }\\n}\\n\",\"keccak256\":\"0x5358948017669c03e157f871d8c38e988f9004dbd0801ad3119d2487f0d40b0b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/access/Ownable.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (access/Ownable.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Context} from \\\"../utils/Context.sol\\\";\\n\\n/**\\n * @dev Contract module which provides a basic access control mechanism, where\\n * there is an account (an owner) that can be granted exclusive access to\\n * specific functions.\\n *\\n * The initial owner is set to the address provided by the deployer. This can\\n * later be changed with {transferOwnership}.\\n *\\n * This module is used through inheritance. It will make available the modifier\\n * `onlyOwner`, which can be applied to your functions to restrict their use to\\n * the owner.\\n */\\nabstract contract Ownable is Context {\\n    address private _owner;\\n\\n    /**\\n     * @dev The caller account is not authorized to perform an operation.\\n     */\\n    error OwnableUnauthorizedAccount(address account);\\n\\n    /**\\n     * @dev The owner is not a valid owner account. (eg. `address(0)`)\\n     */\\n    error OwnableInvalidOwner(address owner);\\n\\n    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);\\n\\n    /**\\n     * @dev Initializes the contract setting the address provided by the deployer as the initial owner.\\n     */\\n    constructor(address initialOwner) {\\n        if (initialOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(initialOwner);\\n    }\\n\\n    /**\\n     * @dev Throws if called by any account other than the owner.\\n     */\\n    modifier onlyOwner() {\\n        _checkOwner();\\n        _;\\n    }\\n\\n    /**\\n     * @dev Returns the address of the current owner.\\n     */\\n    function owner() public view virtual returns (address) {\\n        return _owner;\\n    }\\n\\n    /**\\n     * @dev Throws if the sender is not the owner.\\n     */\\n    function _checkOwner() internal view virtual {\\n        if (owner() != _msgSender()) {\\n            revert OwnableUnauthorizedAccount(_msgSender());\\n        }\\n    }\\n\\n    /**\\n     * @dev Leaves the contract without owner. It will not be possible to call\\n     * `onlyOwner` functions. Can only be called by the current owner.\\n     *\\n     * NOTE: Renouncing ownership will leave the contract without an owner,\\n     * thereby disabling any functionality that is only available to the owner.\\n     */\\n    function renounceOwnership() public virtual onlyOwner {\\n        _transferOwnership(address(0));\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Can only be called by the current owner.\\n     */\\n    function transferOwnership(address newOwner) public virtual onlyOwner {\\n        if (newOwner == address(0)) {\\n            revert OwnableInvalidOwner(address(0));\\n        }\\n        _transferOwnership(newOwner);\\n    }\\n\\n    /**\\n     * @dev Transfers ownership of the contract to a new account (`newOwner`).\\n     * Internal function without access restriction.\\n     */\\n    function _transferOwnership(address newOwner) internal virtual {\\n        address oldOwner = _owner;\\n        _owner = newOwner;\\n        emit OwnershipTransferred(oldOwner, newOwner);\\n    }\\n}\\n\",\"keccak256\":\"0xff6d0bb2e285473e5311d9d3caacb525ae3538a80758c10649a4d61029b017bb\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC1363.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/IERC1363.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC165} from \\\"./IERC165.sol\\\";\\n\\n/**\\n * @title IERC1363\\n * @dev Interface of the ERC-1363 standard as defined in the https://eips.ethereum.org/EIPS/eip-1363[ERC-1363].\\n *\\n * Defines an extension interface for ERC-20 tokens that supports executing code on a recipient contract\\n * after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.\\n */\\ninterface IERC1363 is IERC20, IERC165 {\\n    /*\\n     * Note: the ERC-165 identifier for this interface is 0xb0202a11.\\n     * 0xb0202a11 ===\\n     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^\\n     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^\\n     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))\\n     */\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism\\n     * and then calls {IERC1363Receiver-onTransferReceived} on `to`.\\n     * @param from The address which you want to send tokens from.\\n     * @param to The address which you want to transfer to.\\n     * @param value The amount of tokens to be transferred.\\n     * @param data Additional data with no specified format, sent in call to `to`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens and then calls {IERC1363Spender-onApprovalReceived} on `spender`.\\n     * @param spender The address which will spend the funds.\\n     * @param value The amount of tokens to be spent.\\n     * @param data Additional data with no specified format, sent in call to `spender`.\\n     * @return A boolean value indicating whether the operation succeeded unless throwing.\\n     */\\n    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);\\n}\\n\",\"keccak256\":\"0x9b6b3e7803bc5f2f8cd7ad57db8ac1def61a9930a5a3107df4882e028a9605d7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC165} from \\\"../utils/introspection/IERC165.sol\\\";\\n\",\"keccak256\":\"0xde7e9fd9aee8d4f40772f96bb3b58836cbc6dfc0227014a061947f8821ea9724\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../token/ERC20/IERC20.sol\\\";\\n\",\"keccak256\":\"0xce41876e78d1badc0512229b4d14e4daf83bc1003d7f83978d18e0e56f965b9c\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/IERC5267.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (interfaces/IERC5267.sol)\\n\\npragma solidity ^0.8.20;\\n\\ninterface IERC5267 {\\n    /**\\n     * @dev MAY be emitted to signal that the domain could have changed.\\n     */\\n    event EIP712DomainChanged();\\n\\n    /**\\n     * @dev returns the fields and values that describe the domain separator used by this contract for EIP-712\\n     * signature.\\n     */\\n    function eip712Domain()\\n        external\\n        view\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        );\\n}\\n\",\"keccak256\":\"0x92aa1df62dc3d33f1656d63bede0923e0df0b706ad4137c8b10b0a8fe549fd92\",\"license\":\"MIT\"},\"@openzeppelin/contracts/interfaces/draft-IERC6093.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (interfaces/draft-IERC6093.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Standard ERC-20 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-20 tokens.\\n */\\ninterface IERC20Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC20InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC20InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     * @param allowance Amount of tokens a `spender` is allowed to operate with.\\n     * @param needed Minimum amount required to perform a transfer.\\n     */\\n    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC20InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `spender` to be approved. Used in approvals.\\n     * @param spender Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC20InvalidSpender(address spender);\\n}\\n\\n/**\\n * @dev Standard ERC-721 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-721 tokens.\\n */\\ninterface IERC721Errors {\\n    /**\\n     * @dev Indicates that an address can't be an owner. For example, `address(0)` is a forbidden owner in ERC-20.\\n     * Used in balance queries.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721InvalidOwner(address owner);\\n\\n    /**\\n     * @dev Indicates a `tokenId` whose `owner` is the zero address.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721NonexistentToken(uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates an error related to the ownership over a particular token. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param tokenId Identifier number of a token.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC721InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC721InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC721InsufficientApproval(address operator, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC721InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC721InvalidOperator(address operator);\\n}\\n\\n/**\\n * @dev Standard ERC-1155 Errors\\n * Interface of the https://eips.ethereum.org/EIPS/eip-6093[ERC-6093] custom errors for ERC-1155 tokens.\\n */\\ninterface IERC1155Errors {\\n    /**\\n     * @dev Indicates an error related to the current `balance` of a `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     * @param balance Current balance for the interacting account.\\n     * @param needed Minimum amount required to perform a transfer.\\n     * @param tokenId Identifier number of a token.\\n     */\\n    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);\\n\\n    /**\\n     * @dev Indicates a failure with the token `sender`. Used in transfers.\\n     * @param sender Address whose tokens are being transferred.\\n     */\\n    error ERC1155InvalidSender(address sender);\\n\\n    /**\\n     * @dev Indicates a failure with the token `receiver`. Used in transfers.\\n     * @param receiver Address to which tokens are being transferred.\\n     */\\n    error ERC1155InvalidReceiver(address receiver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator`\\u2019s approval. Used in transfers.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     * @param owner Address of the current owner of a token.\\n     */\\n    error ERC1155MissingApprovalForAll(address operator, address owner);\\n\\n    /**\\n     * @dev Indicates a failure with the `approver` of a token to be approved. Used in approvals.\\n     * @param approver Address initiating an approval operation.\\n     */\\n    error ERC1155InvalidApprover(address approver);\\n\\n    /**\\n     * @dev Indicates a failure with the `operator` to be approved. Used in approvals.\\n     * @param operator Address that may be allowed to operate on tokens without being their owner.\\n     */\\n    error ERC1155InvalidOperator(address operator);\\n\\n    /**\\n     * @dev Indicates an array length mismatch between ids and values in a safeBatchTransferFrom operation.\\n     * Used in batch transfers.\\n     * @param idsLength Length of the array of token identifiers\\n     * @param valuesLength Length of the array of token amounts\\n     */\\n    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);\\n}\\n\",\"keccak256\":\"0x880da465c203cec76b10d72dbd87c80f387df4102274f23eea1f9c9b0918792b\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/ERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/ERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"./IERC20.sol\\\";\\nimport {IERC20Metadata} from \\\"./extensions/IERC20Metadata.sol\\\";\\nimport {Context} from \\\"../../utils/Context.sol\\\";\\nimport {IERC20Errors} from \\\"../../interfaces/draft-IERC6093.sol\\\";\\n\\n/**\\n * @dev Implementation of the {IERC20} interface.\\n *\\n * This implementation is agnostic to the way tokens are created. This means\\n * that a supply mechanism has to be added in a derived contract using {_mint}.\\n *\\n * TIP: For a detailed writeup see our guide\\n * https://forum.openzeppelin.com/t/how-to-implement-erc20-supply-mechanisms/226[How\\n * to implement supply mechanisms].\\n *\\n * The default value of {decimals} is 18. To change this, you should override\\n * this function so it returns a different value.\\n *\\n * We have followed general OpenZeppelin Contracts guidelines: functions revert\\n * instead returning `false` on failure. This behavior is nonetheless\\n * conventional and does not conflict with the expectations of ERC-20\\n * applications.\\n */\\nabstract contract ERC20 is Context, IERC20, IERC20Metadata, IERC20Errors {\\n    mapping(address account => uint256) private _balances;\\n\\n    mapping(address account => mapping(address spender => uint256)) private _allowances;\\n\\n    uint256 private _totalSupply;\\n\\n    string private _name;\\n    string private _symbol;\\n\\n    /**\\n     * @dev Sets the values for {name} and {symbol}.\\n     *\\n     * Both values are immutable: they can only be set once during construction.\\n     */\\n    constructor(string memory name_, string memory symbol_) {\\n        _name = name_;\\n        _symbol = symbol_;\\n    }\\n\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() public view virtual returns (string memory) {\\n        return _name;\\n    }\\n\\n    /**\\n     * @dev Returns the symbol of the token, usually a shorter version of the\\n     * name.\\n     */\\n    function symbol() public view virtual returns (string memory) {\\n        return _symbol;\\n    }\\n\\n    /**\\n     * @dev Returns the number of decimals used to get its user representation.\\n     * For example, if `decimals` equals `2`, a balance of `505` tokens should\\n     * be displayed to a user as `5.05` (`505 / 10 ** 2`).\\n     *\\n     * Tokens usually opt for a value of 18, imitating the relationship between\\n     * Ether and Wei. This is the default value returned by this function, unless\\n     * it's overridden.\\n     *\\n     * NOTE: This information is only used for _display_ purposes: it in\\n     * no way affects any of the arithmetic of the contract, including\\n     * {IERC20-balanceOf} and {IERC20-transfer}.\\n     */\\n    function decimals() public view virtual returns (uint8) {\\n        return 18;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-totalSupply}.\\n     */\\n    function totalSupply() public view virtual returns (uint256) {\\n        return _totalSupply;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-balanceOf}.\\n     */\\n    function balanceOf(address account) public view virtual returns (uint256) {\\n        return _balances[account];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transfer}.\\n     *\\n     * Requirements:\\n     *\\n     * - `to` cannot be the zero address.\\n     * - the caller must have a balance of at least `value`.\\n     */\\n    function transfer(address to, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _transfer(owner, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-allowance}.\\n     */\\n    function allowance(address owner, address spender) public view virtual returns (uint256) {\\n        return _allowances[owner][spender];\\n    }\\n\\n    /**\\n     * @dev See {IERC20-approve}.\\n     *\\n     * NOTE: If `value` is the maximum `uint256`, the allowance is not updated on\\n     * `transferFrom`. This is semantically equivalent to an infinite approval.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     */\\n    function approve(address spender, uint256 value) public virtual returns (bool) {\\n        address owner = _msgSender();\\n        _approve(owner, spender, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev See {IERC20-transferFrom}.\\n     *\\n     * Skips emitting an {Approval} event indicating an allowance update. This is not\\n     * required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve].\\n     *\\n     * NOTE: Does not update the allowance if the current allowance\\n     * is the maximum `uint256`.\\n     *\\n     * Requirements:\\n     *\\n     * - `from` and `to` cannot be the zero address.\\n     * - `from` must have a balance of at least `value`.\\n     * - the caller must have allowance for ``from``'s tokens of at least\\n     * `value`.\\n     */\\n    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {\\n        address spender = _msgSender();\\n        _spendAllowance(from, spender, value);\\n        _transfer(from, to, value);\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to`.\\n     *\\n     * This internal function is equivalent to {transfer}, and can be used to\\n     * e.g. implement automatic token fees, slashing mechanisms, etc.\\n     *\\n     * Emits a {Transfer} event.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _transfer(address from, address to, uint256 value) internal {\\n        if (from == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        if (to == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Transfers a `value` amount of tokens from `from` to `to`, or alternatively mints (or burns) if `from`\\n     * (or `to`) is the zero address. All customizations to transfers, mints, and burns should be done by overriding\\n     * this function.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function _update(address from, address to, uint256 value) internal virtual {\\n        if (from == address(0)) {\\n            // Overflow check required: The rest of the code assumes that totalSupply never overflows\\n            _totalSupply += value;\\n        } else {\\n            uint256 fromBalance = _balances[from];\\n            if (fromBalance < value) {\\n                revert ERC20InsufficientBalance(from, fromBalance, value);\\n            }\\n            unchecked {\\n                // Overflow not possible: value <= fromBalance <= totalSupply.\\n                _balances[from] = fromBalance - value;\\n            }\\n        }\\n\\n        if (to == address(0)) {\\n            unchecked {\\n                // Overflow not possible: value <= totalSupply or value <= fromBalance <= totalSupply.\\n                _totalSupply -= value;\\n            }\\n        } else {\\n            unchecked {\\n                // Overflow not possible: balance + value is at most totalSupply, which we know fits into a uint256.\\n                _balances[to] += value;\\n            }\\n        }\\n\\n        emit Transfer(from, to, value);\\n    }\\n\\n    /**\\n     * @dev Creates a `value` amount of tokens and assigns them to `account`, by transferring it from address(0).\\n     * Relies on the `_update` mechanism\\n     *\\n     * Emits a {Transfer} event with `from` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead.\\n     */\\n    function _mint(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidReceiver(address(0));\\n        }\\n        _update(address(0), account, value);\\n    }\\n\\n    /**\\n     * @dev Destroys a `value` amount of tokens from `account`, lowering the total supply.\\n     * Relies on the `_update` mechanism.\\n     *\\n     * Emits a {Transfer} event with `to` set to the zero address.\\n     *\\n     * NOTE: This function is not virtual, {_update} should be overridden instead\\n     */\\n    function _burn(address account, uint256 value) internal {\\n        if (account == address(0)) {\\n            revert ERC20InvalidSender(address(0));\\n        }\\n        _update(account, address(0), value);\\n    }\\n\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over the `owner`'s tokens.\\n     *\\n     * This internal function is equivalent to `approve`, and can be used to\\n     * e.g. set automatic allowances for certain subsystems, etc.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `owner` cannot be the zero address.\\n     * - `spender` cannot be the zero address.\\n     *\\n     * Overrides to this logic should be done to the variant with an additional `bool emitEvent` argument.\\n     */\\n    function _approve(address owner, address spender, uint256 value) internal {\\n        _approve(owner, spender, value, true);\\n    }\\n\\n    /**\\n     * @dev Variant of {_approve} with an optional flag to enable or disable the {Approval} event.\\n     *\\n     * By default (when calling {_approve}) the flag is set to true. On the other hand, approval changes made by\\n     * `_spendAllowance` during the `transferFrom` operation set the flag to false. This saves gas by not emitting any\\n     * `Approval` event during `transferFrom` operations.\\n     *\\n     * Anyone who wishes to continue emitting `Approval` events on the`transferFrom` operation can force the flag to\\n     * true using the following override:\\n     *\\n     * ```solidity\\n     * function _approve(address owner, address spender, uint256 value, bool) internal virtual override {\\n     *     super._approve(owner, spender, value, true);\\n     * }\\n     * ```\\n     *\\n     * Requirements are the same as {_approve}.\\n     */\\n    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal virtual {\\n        if (owner == address(0)) {\\n            revert ERC20InvalidApprover(address(0));\\n        }\\n        if (spender == address(0)) {\\n            revert ERC20InvalidSpender(address(0));\\n        }\\n        _allowances[owner][spender] = value;\\n        if (emitEvent) {\\n            emit Approval(owner, spender, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Updates `owner`'s allowance for `spender` based on spent `value`.\\n     *\\n     * Does not update the allowance value in case of infinite allowance.\\n     * Revert if not enough allowance is available.\\n     *\\n     * Does not emit an {Approval} event.\\n     */\\n    function _spendAllowance(address owner, address spender, uint256 value) internal virtual {\\n        uint256 currentAllowance = allowance(owner, spender);\\n        if (currentAllowance < type(uint256).max) {\\n            if (currentAllowance < value) {\\n                revert ERC20InsufficientAllowance(spender, currentAllowance, value);\\n            }\\n            unchecked {\\n                _approve(owner, spender, currentAllowance - value, false);\\n            }\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x41f6b3b9e030561e7896dbef372b499cc8d418a80c3884a4d65a68f2fdc7493a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 standard as defined in the ERC.\\n */\\ninterface IERC20 {\\n    /**\\n     * @dev Emitted when `value` tokens are moved from one account (`from`) to\\n     * another (`to`).\\n     *\\n     * Note that `value` may be zero.\\n     */\\n    event Transfer(address indexed from, address indexed to, uint256 value);\\n\\n    /**\\n     * @dev Emitted when the allowance of a `spender` for an `owner` is set by\\n     * a call to {approve}. `value` is the new allowance.\\n     */\\n    event Approval(address indexed owner, address indexed spender, uint256 value);\\n\\n    /**\\n     * @dev Returns the value of tokens in existence.\\n     */\\n    function totalSupply() external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the value of tokens owned by `account`.\\n     */\\n    function balanceOf(address account) external view returns (uint256);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from the caller's account to `to`.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transfer(address to, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Returns the remaining number of tokens that `spender` will be\\n     * allowed to spend on behalf of `owner` through {transferFrom}. This is\\n     * zero by default.\\n     *\\n     * This value changes when {approve} or {transferFrom} are called.\\n     */\\n    function allowance(address owner, address spender) external view returns (uint256);\\n\\n    /**\\n     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the\\n     * caller's tokens.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * IMPORTANT: Beware that changing an allowance with this method brings the risk\\n     * that someone may use both the old and the new allowance by unfortunate\\n     * transaction ordering. One possible solution to mitigate this race\\n     * condition is to first reduce the spender's allowance to 0 and set the\\n     * desired value afterwards:\\n     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729\\n     *\\n     * Emits an {Approval} event.\\n     */\\n    function approve(address spender, uint256 value) external returns (bool);\\n\\n    /**\\n     * @dev Moves a `value` amount of tokens from `from` to `to` using the\\n     * allowance mechanism. `value` is then deducted from the caller's\\n     * allowance.\\n     *\\n     * Returns a boolean value indicating whether the operation succeeded.\\n     *\\n     * Emits a {Transfer} event.\\n     */\\n    function transferFrom(address from, address to, uint256 value) external returns (bool);\\n}\\n\",\"keccak256\":\"0xe06a3f08a987af6ad2e1c1e774405d4fe08f1694b67517438b467cecf0da0ef7\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/ERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20Permit} from \\\"./IERC20Permit.sol\\\";\\nimport {ERC20} from \\\"../ERC20.sol\\\";\\nimport {ECDSA} from \\\"../../../utils/cryptography/ECDSA.sol\\\";\\nimport {EIP712} from \\\"../../../utils/cryptography/EIP712.sol\\\";\\nimport {Nonces} from \\\"../../../utils/Nonces.sol\\\";\\n\\n/**\\n * @dev Implementation of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n */\\nabstract contract ERC20Permit is ERC20, IERC20Permit, EIP712, Nonces {\\n    bytes32 private constant PERMIT_TYPEHASH =\\n        keccak256(\\\"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)\\\");\\n\\n    /**\\n     * @dev Permit deadline has expired.\\n     */\\n    error ERC2612ExpiredSignature(uint256 deadline);\\n\\n    /**\\n     * @dev Mismatched signature.\\n     */\\n    error ERC2612InvalidSigner(address signer, address owner);\\n\\n    /**\\n     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `\\\"1\\\"`.\\n     *\\n     * It's a good idea to use the same `name` that is defined as the ERC-20 token name.\\n     */\\n    constructor(string memory name) EIP712(name, \\\"1\\\") {}\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) public virtual {\\n        if (block.timestamp > deadline) {\\n            revert ERC2612ExpiredSignature(deadline);\\n        }\\n\\n        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));\\n\\n        bytes32 hash = _hashTypedDataV4(structHash);\\n\\n        address signer = ECDSA.recover(hash, v, r, s);\\n        if (signer != owner) {\\n            revert ERC2612InvalidSigner(signer, owner);\\n        }\\n\\n        _approve(owner, spender, value);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    function nonces(address owner) public view virtual override(IERC20Permit, Nonces) returns (uint256) {\\n        return super.nonces(owner);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC20Permit\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view virtual returns (bytes32) {\\n        return _domainSeparatorV4();\\n    }\\n}\\n\",\"keccak256\":\"0xaa7f0646f49ebe2606eeca169f85c56451bbaeeeb06265fa076a03369a25d1d3\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Metadata.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\n\\n/**\\n * @dev Interface for the optional metadata functions from the ERC-20 standard.\\n */\\ninterface IERC20Metadata is IERC20 {\\n    /**\\n     * @dev Returns the name of the token.\\n     */\\n    function name() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the symbol of the token.\\n     */\\n    function symbol() external view returns (string memory);\\n\\n    /**\\n     * @dev Returns the decimals places of the token.\\n     */\\n    function decimals() external view returns (uint8);\\n}\\n\",\"keccak256\":\"0x70f2f713b13b7ce4610bcd0ac9fec0f3cc43693b043abcb8dc40a42a726eb330\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/extensions/IERC20Permit.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-20 Permit extension allowing approvals to be made via signatures, as defined in\\n * https://eips.ethereum.org/EIPS/eip-2612[ERC-2612].\\n *\\n * Adds the {permit} method, which can be used to change an account's ERC-20 allowance (see {IERC20-allowance}) by\\n * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't\\n * need to send a transaction, and thus is not required to hold Ether at all.\\n *\\n * ==== Security Considerations\\n *\\n * There are two important considerations concerning the use of `permit`. The first is that a valid permit signature\\n * expresses an allowance, and it should not be assumed to convey additional meaning. In particular, it should not be\\n * considered as an intention to spend the allowance in any specific way. The second is that because permits have\\n * built-in replay protection and can be submitted by anyone, they can be frontrun. A protocol that uses permits should\\n * take this into consideration and allow a `permit` call to fail. Combining these two aspects, a pattern that may be\\n * generally recommended is:\\n *\\n * ```solidity\\n * function doThingWithPermit(..., uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) public {\\n *     try token.permit(msg.sender, address(this), value, deadline, v, r, s) {} catch {}\\n *     doThing(..., value);\\n * }\\n *\\n * function doThing(..., uint256 value) public {\\n *     token.safeTransferFrom(msg.sender, address(this), value);\\n *     ...\\n * }\\n * ```\\n *\\n * Observe that: 1) `msg.sender` is used as the owner, leaving no ambiguity as to the signer intent, and 2) the use of\\n * `try/catch` allows the permit to fail and makes the code tolerant to frontrunning. (See also\\n * {SafeERC20-safeTransferFrom}).\\n *\\n * Additionally, note that smart contract wallets (such as Argent or Safe) are not able to produce permit signatures, so\\n * contracts should have entry points that don't rely on permit.\\n */\\ninterface IERC20Permit {\\n    /**\\n     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,\\n     * given ``owner``'s signed approval.\\n     *\\n     * IMPORTANT: The same issues {IERC20-approve} has related to transaction\\n     * ordering also apply here.\\n     *\\n     * Emits an {Approval} event.\\n     *\\n     * Requirements:\\n     *\\n     * - `spender` cannot be the zero address.\\n     * - `deadline` must be a timestamp in the future.\\n     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`\\n     * over the EIP712-formatted function arguments.\\n     * - the signature must use ``owner``'s current nonce (see {nonces}).\\n     *\\n     * For more information on the signature format, see the\\n     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP\\n     * section].\\n     *\\n     * CAUTION: See Security Considerations above.\\n     */\\n    function permit(\\n        address owner,\\n        address spender,\\n        uint256 value,\\n        uint256 deadline,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) external;\\n\\n    /**\\n     * @dev Returns the current nonce for `owner`. This value must be\\n     * included whenever a signature is generated for {permit}.\\n     *\\n     * Every successful call to {permit} increases ``owner``'s nonce by one. This\\n     * prevents a signature from being used multiple times.\\n     */\\n    function nonces(address owner) external view returns (uint256);\\n\\n    /**\\n     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function DOMAIN_SEPARATOR() external view returns (bytes32);\\n}\\n\",\"keccak256\":\"0x27dbc90e5136ffe46c04f7596fc2dbcc3acebd8d504da3d93fdb8496e6de04f6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (token/ERC20/utils/SafeERC20.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {IERC20} from \\\"../IERC20.sol\\\";\\nimport {IERC1363} from \\\"../../../interfaces/IERC1363.sol\\\";\\n\\n/**\\n * @title SafeERC20\\n * @dev Wrappers around ERC-20 operations that throw on failure (when the token\\n * contract returns false). Tokens that return no value (and instead revert or\\n * throw on failure) are also supported, non-reverting calls are assumed to be\\n * successful.\\n * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,\\n * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.\\n */\\nlibrary SafeERC20 {\\n    /**\\n     * @dev An operation with an ERC-20 token failed.\\n     */\\n    error SafeERC20FailedOperation(address token);\\n\\n    /**\\n     * @dev Indicates a failed `decreaseAllowance` request.\\n     */\\n    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransfer(IERC20 token, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the\\n     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.\\n     */\\n    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {\\n        _callOptionalReturn(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransfer} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransfer(IERC20 token, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transfer, (to, value)));\\n    }\\n\\n    /**\\n     * @dev Variant of {safeTransferFrom} that returns a bool instead of reverting if the operation is not successful.\\n     */\\n    function trySafeTransferFrom(IERC20 token, address from, address to, uint256 value) internal returns (bool) {\\n        return _callOptionalReturnBool(token, abi.encodeCall(token.transferFrom, (from, to, value)));\\n    }\\n\\n    /**\\n     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeIncreaseAllowance(IERC20 token, address spender, uint256 value) internal {\\n        uint256 oldAllowance = token.allowance(address(this), spender);\\n        forceApprove(token, spender, oldAllowance + value);\\n    }\\n\\n    /**\\n     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no\\n     * value, non-reverting calls are assumed to be successful.\\n     *\\n     * IMPORTANT: If the token implements ERC-7674 (ERC-20 with temporary allowance), and if the \\\"client\\\"\\n     * smart contract uses ERC-7674 to set temporary allowances, then the \\\"client\\\" smart contract should avoid using\\n     * this function. Performing a {safeIncreaseAllowance} or {safeDecreaseAllowance} operation on a token contract\\n     * that has a non-zero temporary allowance (for that particular owner-spender) will result in unexpected behavior.\\n     */\\n    function safeDecreaseAllowance(IERC20 token, address spender, uint256 requestedDecrease) internal {\\n        unchecked {\\n            uint256 currentAllowance = token.allowance(address(this), spender);\\n            if (currentAllowance < requestedDecrease) {\\n                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);\\n            }\\n            forceApprove(token, spender, currentAllowance - requestedDecrease);\\n        }\\n    }\\n\\n    /**\\n     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,\\n     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval\\n     * to be set to zero before setting it to a non-zero value, such as USDT.\\n     *\\n     * NOTE: If the token implements ERC-7674, this function will not modify any temporary allowance. This function\\n     * only sets the \\\"standard\\\" allowance. Any temporary allowance will remain active, in addition to the value being\\n     * set here.\\n     */\\n    function forceApprove(IERC20 token, address spender, uint256 value) internal {\\n        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));\\n\\n        if (!_callOptionalReturnBool(token, approvalCall)) {\\n            _callOptionalReturn(token, abi.encodeCall(token.approve, (spender, 0)));\\n            _callOptionalReturn(token, approvalCall);\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferAndCall, with a fallback to the simple {ERC20} transfer if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            safeTransfer(token, to, value);\\n        } else if (!token.transferAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} transferFromAndCall, with a fallback to the simple {ERC20} transferFrom if the target\\n     * has no code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function transferFromAndCallRelaxed(\\n        IERC1363 token,\\n        address from,\\n        address to,\\n        uint256 value,\\n        bytes memory data\\n    ) internal {\\n        if (to.code.length == 0) {\\n            safeTransferFrom(token, from, to, value);\\n        } else if (!token.transferFromAndCall(from, to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Performs an {ERC1363} approveAndCall, with a fallback to the simple {ERC20} approve if the target has no\\n     * code. This can be used to implement an {ERC721}-like safe transfer that rely on {ERC1363} checks when\\n     * targeting contracts.\\n     *\\n     * NOTE: When the recipient address (`to`) has no code (i.e. is an EOA), this function behaves as {forceApprove}.\\n     * Opposedly, when the recipient address (`to`) has code, this function only attempts to call {ERC1363-approveAndCall}\\n     * once without retrying, and relies on the returned value to be true.\\n     *\\n     * Reverts if the returned value is other than `true`.\\n     */\\n    function approveAndCallRelaxed(IERC1363 token, address to, uint256 value, bytes memory data) internal {\\n        if (to.code.length == 0) {\\n            forceApprove(token, to, value);\\n        } else if (!token.approveAndCall(to, value, data)) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturnBool} that reverts if call fails to meet the requirements.\\n     */\\n    function _callOptionalReturn(IERC20 token, bytes memory data) private {\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            let success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            // bubble errors\\n            if iszero(success) {\\n                let ptr := mload(0x40)\\n                returndatacopy(ptr, 0, returndatasize())\\n                revert(ptr, returndatasize())\\n            }\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n\\n        if (returnSize == 0 ? address(token).code.length == 0 : returnValue != 1) {\\n            revert SafeERC20FailedOperation(address(token));\\n        }\\n    }\\n\\n    /**\\n     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement\\n     * on the return value: the return value is optional (but if data is returned, it must not be false).\\n     * @param token The token targeted by the call.\\n     * @param data The call data (encoded using abi.encode or one of its variants).\\n     *\\n     * This is a variant of {_callOptionalReturn} that silently catches all reverts and returns a bool instead.\\n     */\\n    function _callOptionalReturnBool(IERC20 token, bytes memory data) private returns (bool) {\\n        bool success;\\n        uint256 returnSize;\\n        uint256 returnValue;\\n        assembly (\\\"memory-safe\\\") {\\n            success := call(gas(), token, 0, add(data, 0x20), mload(data), 0, 0x20)\\n            returnSize := returndatasize()\\n            returnValue := mload(0)\\n        }\\n        return success && (returnSize == 0 ? address(token).code.length > 0 : returnValue == 1);\\n    }\\n}\\n\",\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Context.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.1) (utils/Context.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides information about the current execution context, including the\\n * sender of the transaction and its data. While these are generally available\\n * via msg.sender and msg.data, they should not be accessed in such a direct\\n * manner, since when dealing with meta-transactions the account sending and\\n * paying for execution may not be the actual sender (as far as an application\\n * is concerned).\\n *\\n * This contract is only required for intermediate, library-like contracts.\\n */\\nabstract contract Context {\\n    function _msgSender() internal view virtual returns (address) {\\n        return msg.sender;\\n    }\\n\\n    function _msgData() internal view virtual returns (bytes calldata) {\\n        return msg.data;\\n    }\\n\\n    function _contextSuffixLength() internal view virtual returns (uint256) {\\n        return 0;\\n    }\\n}\\n\",\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Nonces.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.0.0) (utils/Nonces.sol)\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Provides tracking nonces for addresses. Nonces will only increment.\\n */\\nabstract contract Nonces {\\n    /**\\n     * @dev The nonce used for an `account` is not the expected current nonce.\\n     */\\n    error InvalidAccountNonce(address account, uint256 currentNonce);\\n\\n    mapping(address account => uint256) private _nonces;\\n\\n    /**\\n     * @dev Returns the next unused nonce for an address.\\n     */\\n    function nonces(address owner) public view virtual returns (uint256) {\\n        return _nonces[owner];\\n    }\\n\\n    /**\\n     * @dev Consumes a nonce.\\n     *\\n     * Returns the current value and increments nonce.\\n     */\\n    function _useNonce(address owner) internal virtual returns (uint256) {\\n        // For each account, the nonce has an initial value of 0, can only be incremented by one, and cannot be\\n        // decremented or reset. This guarantees that the nonce never overflows.\\n        unchecked {\\n            // It is important to do x++ and not ++x here.\\n            return _nonces[owner]++;\\n        }\\n    }\\n\\n    /**\\n     * @dev Same as {_useNonce} but checking that `nonce` is the next valid for `owner`.\\n     */\\n    function _useCheckedNonce(address owner, uint256 nonce) internal virtual {\\n        uint256 current = _useNonce(owner);\\n        if (nonce != current) {\\n            revert InvalidAccountNonce(owner, current);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x0082767004fca261c332e9ad100868327a863a88ef724e844857128845ab350f\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Panic.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/Panic.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Helper library for emitting standardized panic codes.\\n *\\n * ```solidity\\n * contract Example {\\n *      using Panic for uint256;\\n *\\n *      // Use any of the declared internal constants\\n *      function foo() { Panic.GENERIC.panic(); }\\n *\\n *      // Alternatively\\n *      function foo() { Panic.panic(Panic.GENERIC); }\\n * }\\n * ```\\n *\\n * Follows the list from https://github.com/ethereum/solidity/blob/v0.8.24/libsolutil/ErrorCodes.h[libsolutil].\\n *\\n * _Available since v5.1._\\n */\\n// slither-disable-next-line unused-state\\nlibrary Panic {\\n    /// @dev generic / unspecified error\\n    uint256 internal constant GENERIC = 0x00;\\n    /// @dev used by the assert() builtin\\n    uint256 internal constant ASSERT = 0x01;\\n    /// @dev arithmetic underflow or overflow\\n    uint256 internal constant UNDER_OVERFLOW = 0x11;\\n    /// @dev division or modulo by zero\\n    uint256 internal constant DIVISION_BY_ZERO = 0x12;\\n    /// @dev enum conversion error\\n    uint256 internal constant ENUM_CONVERSION_ERROR = 0x21;\\n    /// @dev invalid encoding in storage\\n    uint256 internal constant STORAGE_ENCODING_ERROR = 0x22;\\n    /// @dev empty array pop\\n    uint256 internal constant EMPTY_ARRAY_POP = 0x31;\\n    /// @dev array out of bounds access\\n    uint256 internal constant ARRAY_OUT_OF_BOUNDS = 0x32;\\n    /// @dev resource error (too large allocation or too large array)\\n    uint256 internal constant RESOURCE_ERROR = 0x41;\\n    /// @dev calling invalid internal function\\n    uint256 internal constant INVALID_INTERNAL_FUNCTION = 0x51;\\n\\n    /// @dev Reverts with a panic code. Recommended to use with\\n    /// the internal constants with predefined codes.\\n    function panic(uint256 code) internal pure {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, 0x4e487b71)\\n            mstore(0x20, code)\\n            revert(0x1c, 0x24)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/ShortStrings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/ShortStrings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {StorageSlot} from \\\"./StorageSlot.sol\\\";\\n\\n// | string  | 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA   |\\n// | length  | 0x                                                              BB |\\ntype ShortString is bytes32;\\n\\n/**\\n * @dev This library provides functions to convert short memory strings\\n * into a `ShortString` type that can be used as an immutable variable.\\n *\\n * Strings of arbitrary length can be optimized using this library if\\n * they are short enough (up to 31 bytes) by packing them with their\\n * length (1 byte) in a single EVM word (32 bytes). Additionally, a\\n * fallback mechanism can be used for every other case.\\n *\\n * Usage example:\\n *\\n * ```solidity\\n * contract Named {\\n *     using ShortStrings for *;\\n *\\n *     ShortString private immutable _name;\\n *     string private _nameFallback;\\n *\\n *     constructor(string memory contractName) {\\n *         _name = contractName.toShortStringWithFallback(_nameFallback);\\n *     }\\n *\\n *     function name() external view returns (string memory) {\\n *         return _name.toStringWithFallback(_nameFallback);\\n *     }\\n * }\\n * ```\\n */\\nlibrary ShortStrings {\\n    // Used as an identifier for strings longer than 31 bytes.\\n    bytes32 private constant FALLBACK_SENTINEL = 0x00000000000000000000000000000000000000000000000000000000000000FF;\\n\\n    error StringTooLong(string str);\\n    error InvalidShortString();\\n\\n    /**\\n     * @dev Encode a string of at most 31 chars into a `ShortString`.\\n     *\\n     * This will trigger a `StringTooLong` error is the input string is too long.\\n     */\\n    function toShortString(string memory str) internal pure returns (ShortString) {\\n        bytes memory bstr = bytes(str);\\n        if (bstr.length > 31) {\\n            revert StringTooLong(str);\\n        }\\n        return ShortString.wrap(bytes32(uint256(bytes32(bstr)) | bstr.length));\\n    }\\n\\n    /**\\n     * @dev Decode a `ShortString` back to a \\\"normal\\\" string.\\n     */\\n    function toString(ShortString sstr) internal pure returns (string memory) {\\n        uint256 len = byteLength(sstr);\\n        // using `new string(len)` would work locally but is not memory safe.\\n        string memory str = new string(32);\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(str, len)\\n            mstore(add(str, 0x20), sstr)\\n        }\\n        return str;\\n    }\\n\\n    /**\\n     * @dev Return the length of a `ShortString`.\\n     */\\n    function byteLength(ShortString sstr) internal pure returns (uint256) {\\n        uint256 result = uint256(ShortString.unwrap(sstr)) & 0xFF;\\n        if (result > 31) {\\n            revert InvalidShortString();\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Encode a string into a `ShortString`, or write it to storage if it is too long.\\n     */\\n    function toShortStringWithFallback(string memory value, string storage store) internal returns (ShortString) {\\n        if (bytes(value).length < 32) {\\n            return toShortString(value);\\n        } else {\\n            StorageSlot.getStringSlot(store).value = value;\\n            return ShortString.wrap(FALLBACK_SENTINEL);\\n        }\\n    }\\n\\n    /**\\n     * @dev Decode a string that was encoded to `ShortString` or written to storage using {toShortStringWithFallback}.\\n     */\\n    function toStringWithFallback(ShortString value, string storage store) internal pure returns (string memory) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return toString(value);\\n        } else {\\n            return store;\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the length of a string that was encoded to `ShortString` or written to storage using\\n     * {toShortStringWithFallback}.\\n     *\\n     * WARNING: This will return the \\\"byte length\\\" of the string. This may not reflect the actual length in terms of\\n     * actual characters as the UTF-8 encoding of a single character can span over multiple bytes.\\n     */\\n    function byteLengthWithFallback(ShortString value, string storage store) internal view returns (uint256) {\\n        if (ShortString.unwrap(value) != FALLBACK_SENTINEL) {\\n            return byteLength(value);\\n        } else {\\n            return bytes(store).length;\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x1fcf8cceb1a67e6c8512267e780933c4a3f63ef44756e6c818fda79be51c8402\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/StorageSlot.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/StorageSlot.sol)\\n// This file was procedurally generated from scripts/generate/templates/StorageSlot.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Library for reading and writing primitive types to specific storage slots.\\n *\\n * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.\\n * This library helps with reading and writing to such slots without the need for inline assembly.\\n *\\n * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.\\n *\\n * Example usage to set ERC-1967 implementation slot:\\n * ```solidity\\n * contract ERC1967 {\\n *     // Define the slot. Alternatively, use the SlotDerivation library to derive the slot.\\n *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;\\n *\\n *     function _getImplementation() internal view returns (address) {\\n *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;\\n *     }\\n *\\n *     function _setImplementation(address newImplementation) internal {\\n *         require(newImplementation.code.length > 0);\\n *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;\\n *     }\\n * }\\n * ```\\n *\\n * TIP: Consider using this library along with {SlotDerivation}.\\n */\\nlibrary StorageSlot {\\n    struct AddressSlot {\\n        address value;\\n    }\\n\\n    struct BooleanSlot {\\n        bool value;\\n    }\\n\\n    struct Bytes32Slot {\\n        bytes32 value;\\n    }\\n\\n    struct Uint256Slot {\\n        uint256 value;\\n    }\\n\\n    struct Int256Slot {\\n        int256 value;\\n    }\\n\\n    struct StringSlot {\\n        string value;\\n    }\\n\\n    struct BytesSlot {\\n        bytes value;\\n    }\\n\\n    /**\\n     * @dev Returns an `AddressSlot` with member `value` located at `slot`.\\n     */\\n    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BooleanSlot` with member `value` located at `slot`.\\n     */\\n    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Bytes32Slot` with member `value` located at `slot`.\\n     */\\n    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Uint256Slot` with member `value` located at `slot`.\\n     */\\n    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `Int256Slot` with member `value` located at `slot`.\\n     */\\n    function getInt256Slot(bytes32 slot) internal pure returns (Int256Slot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `StringSlot` with member `value` located at `slot`.\\n     */\\n    function getStringSlot(bytes32 slot) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `StringSlot` representation of the string storage pointer `store`.\\n     */\\n    function getStringSlot(string storage store) internal pure returns (StringSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns a `BytesSlot` with member `value` located at `slot`.\\n     */\\n    function getBytesSlot(bytes32 slot) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := slot\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns an `BytesSlot` representation of the bytes storage pointer `store`.\\n     */\\n    function getBytesSlot(bytes storage store) internal pure returns (BytesSlot storage r) {\\n        assembly (\\\"memory-safe\\\") {\\n            r.slot := store.slot\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/Strings.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/Strings.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Math} from \\\"./math/Math.sol\\\";\\nimport {SafeCast} from \\\"./math/SafeCast.sol\\\";\\nimport {SignedMath} from \\\"./math/SignedMath.sol\\\";\\n\\n/**\\n * @dev String operations.\\n */\\nlibrary Strings {\\n    using SafeCast for *;\\n\\n    bytes16 private constant HEX_DIGITS = \\\"0123456789abcdef\\\";\\n    uint8 private constant ADDRESS_LENGTH = 20;\\n    uint256 private constant SPECIAL_CHARS_LOOKUP =\\n        (1 << 0x08) | // backspace\\n            (1 << 0x09) | // tab\\n            (1 << 0x0a) | // newline\\n            (1 << 0x0c) | // form feed\\n            (1 << 0x0d) | // carriage return\\n            (1 << 0x22) | // double quote\\n            (1 << 0x5c); // backslash\\n\\n    /**\\n     * @dev The `value` string doesn't fit in the specified `length`.\\n     */\\n    error StringsInsufficientHexLength(uint256 value, uint256 length);\\n\\n    /**\\n     * @dev The string being parsed contains characters that are not in scope of the given base.\\n     */\\n    error StringsInvalidChar();\\n\\n    /**\\n     * @dev The string being parsed is not a properly formatted address.\\n     */\\n    error StringsInvalidAddressFormat();\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` decimal representation.\\n     */\\n    function toString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            uint256 length = Math.log10(value) + 1;\\n            string memory buffer = new string(length);\\n            uint256 ptr;\\n            assembly (\\\"memory-safe\\\") {\\n                ptr := add(buffer, add(32, length))\\n            }\\n            while (true) {\\n                ptr--;\\n                assembly (\\\"memory-safe\\\") {\\n                    mstore8(ptr, byte(mod(value, 10), HEX_DIGITS))\\n                }\\n                value /= 10;\\n                if (value == 0) break;\\n            }\\n            return buffer;\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `int256` to its ASCII `string` decimal representation.\\n     */\\n    function toStringSigned(int256 value) internal pure returns (string memory) {\\n        return string.concat(value < 0 ? \\\"-\\\" : \\\"\\\", toString(SignedMath.abs(value)));\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation.\\n     */\\n    function toHexString(uint256 value) internal pure returns (string memory) {\\n        unchecked {\\n            return toHexString(value, Math.log256(value) + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts a `uint256` to its ASCII `string` hexadecimal representation with fixed length.\\n     */\\n    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {\\n        uint256 localValue = value;\\n        bytes memory buffer = new bytes(2 * length + 2);\\n        buffer[0] = \\\"0\\\";\\n        buffer[1] = \\\"x\\\";\\n        for (uint256 i = 2 * length + 1; i > 1; --i) {\\n            buffer[i] = HEX_DIGITS[localValue & 0xf];\\n            localValue >>= 4;\\n        }\\n        if (localValue != 0) {\\n            revert StringsInsufficientHexLength(value, length);\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its not checksummed ASCII `string` hexadecimal\\n     * representation.\\n     */\\n    function toHexString(address addr) internal pure returns (string memory) {\\n        return toHexString(uint256(uint160(addr)), ADDRESS_LENGTH);\\n    }\\n\\n    /**\\n     * @dev Converts an `address` with fixed length of 20 bytes to its checksummed ASCII `string` hexadecimal\\n     * representation, according to EIP-55.\\n     */\\n    function toChecksumHexString(address addr) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(toHexString(addr));\\n\\n        // hash the hex part of buffer (skip length + 2 bytes, length 40)\\n        uint256 hashValue;\\n        assembly (\\\"memory-safe\\\") {\\n            hashValue := shr(96, keccak256(add(buffer, 0x22), 40))\\n        }\\n\\n        for (uint256 i = 41; i > 1; --i) {\\n            // possible values for buffer[i] are 48 (0) to 57 (9) and 97 (a) to 102 (f)\\n            if (hashValue & 0xf > 7 && uint8(buffer[i]) > 96) {\\n                // case shift by xoring with 0x20\\n                buffer[i] ^= 0x20;\\n            }\\n            hashValue >>= 4;\\n        }\\n        return string(buffer);\\n    }\\n\\n    /**\\n     * @dev Returns true if the two strings are equal.\\n     */\\n    function equal(string memory a, string memory b) internal pure returns (bool) {\\n        return bytes(a).length == bytes(b).length && keccak256(bytes(a)) == keccak256(bytes(b));\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input) internal pure returns (uint256) {\\n        return parseUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[0-9]*`\\n     * - The result must fit into an `uint256` type\\n     */\\n    function parseUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseUint-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 9) return (false, 0);\\n            result *= 10;\\n            result += chr;\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a decimal string and returns the value as a `int256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input) internal pure returns (int256) {\\n        return parseInt(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `[-+]?[0-9]*`\\n     * - The result must fit in an `int256` type.\\n     */\\n    function parseInt(string memory input, uint256 begin, uint256 end) internal pure returns (int256) {\\n        (bool success, int256 value) = tryParseInt(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseInt-string} that returns false if the parsing fails because of an invalid character or if\\n     * the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(string memory input) internal pure returns (bool success, int256 value) {\\n        return _tryParseIntUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    uint256 private constant ABS_MIN_INT256 = 2 ** 255;\\n\\n    /**\\n     * @dev Variant of {parseInt-string-uint256-uint256} that returns false if the parsing fails because of an invalid\\n     * character or if the result does not fit in a `int256`.\\n     *\\n     * NOTE: This function will revert if the absolute value of the result does not fit in a `uint256`.\\n     */\\n    function tryParseInt(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, int256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseIntUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseInt-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseIntUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, int256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // Check presence of a negative sign.\\n        bytes1 sign = begin == end ? bytes1(0) : bytes1(_unsafeReadBytesOffset(buffer, begin)); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        bool positiveSign = sign == bytes1(\\\"+\\\");\\n        bool negativeSign = sign == bytes1(\\\"-\\\");\\n        uint256 offset = (positiveSign || negativeSign).toUint();\\n\\n        (bool absSuccess, uint256 absValue) = tryParseUint(input, begin + offset, end);\\n\\n        if (absSuccess && absValue < ABS_MIN_INT256) {\\n            return (true, negativeSign ? -int256(absValue) : int256(absValue));\\n        } else if (absSuccess && negativeSign && absValue == ABS_MIN_INT256) {\\n            return (true, type(int256).min);\\n        } else return (false, 0);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as a `uint256`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input) internal pure returns (uint256) {\\n        return parseHexUint(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]*`\\n     * - The result must fit in an `uint256` type.\\n     */\\n    function parseHexUint(string memory input, uint256 begin, uint256 end) internal pure returns (uint256) {\\n        (bool success, uint256 value) = tryParseHexUint(input, begin, end);\\n        if (!success) revert StringsInvalidChar();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string} that returns false if the parsing fails because of an invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(string memory input) internal pure returns (bool success, uint256 value) {\\n        return _tryParseHexUintUncheckedBounds(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseHexUint-string-uint256-uint256} that returns false if the parsing fails because of an\\n     * invalid character.\\n     *\\n     * NOTE: This function will revert if the result does not fit in a `uint256`.\\n     */\\n    function tryParseHexUint(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, uint256 value) {\\n        if (end > bytes(input).length || begin > end) return (false, 0);\\n        return _tryParseHexUintUncheckedBounds(input, begin, end);\\n    }\\n\\n    /**\\n     * @dev Implementation of {tryParseHexUint-string-uint256-uint256} that does not check bounds. Caller should make sure that\\n     * `begin <= end <= input.length`. Other inputs would result in undefined behavior.\\n     */\\n    function _tryParseHexUintUncheckedBounds(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) private pure returns (bool success, uint256 value) {\\n        bytes memory buffer = bytes(input);\\n\\n        // skip 0x prefix if present\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(buffer, begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 offset = hasPrefix.toUint() * 2;\\n\\n        uint256 result = 0;\\n        for (uint256 i = begin + offset; i < end; ++i) {\\n            uint8 chr = _tryParseChr(bytes1(_unsafeReadBytesOffset(buffer, i)));\\n            if (chr > 15) return (false, 0);\\n            result *= 16;\\n            unchecked {\\n                // Multiplying by 16 is equivalent to a shift of 4 bits (with additional overflow check).\\n                // This guarantees that adding a value < 16 will not cause an overflow, hence the unchecked.\\n                result += chr;\\n            }\\n        }\\n        return (true, result);\\n    }\\n\\n    /**\\n     * @dev Parse a hexadecimal string (with or without \\\"0x\\\" prefix), and returns the value as an `address`.\\n     *\\n     * Requirements:\\n     * - The string must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input) internal pure returns (address) {\\n        return parseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that parses a substring of `input` located between position `begin` (included) and\\n     * `end` (excluded).\\n     *\\n     * Requirements:\\n     * - The substring must be formatted as `(0x)?[0-9a-fA-F]{40}`\\n     */\\n    function parseAddress(string memory input, uint256 begin, uint256 end) internal pure returns (address) {\\n        (bool success, address value) = tryParseAddress(input, begin, end);\\n        if (!success) revert StringsInvalidAddressFormat();\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string} that returns false if the parsing fails because the input is not a properly\\n     * formatted address. See {parseAddress-string} requirements.\\n     */\\n    function tryParseAddress(string memory input) internal pure returns (bool success, address value) {\\n        return tryParseAddress(input, 0, bytes(input).length);\\n    }\\n\\n    /**\\n     * @dev Variant of {parseAddress-string-uint256-uint256} that returns false if the parsing fails because input is not a properly\\n     * formatted address. See {parseAddress-string-uint256-uint256} requirements.\\n     */\\n    function tryParseAddress(\\n        string memory input,\\n        uint256 begin,\\n        uint256 end\\n    ) internal pure returns (bool success, address value) {\\n        if (end > bytes(input).length || begin > end) return (false, address(0));\\n\\n        bool hasPrefix = (end > begin + 1) && bytes2(_unsafeReadBytesOffset(bytes(input), begin)) == bytes2(\\\"0x\\\"); // don't do out-of-bound (possibly unsafe) read if sub-string is empty\\n        uint256 expectedLength = 40 + hasPrefix.toUint() * 2;\\n\\n        // check that input is the correct length\\n        if (end - begin == expectedLength) {\\n            // length guarantees that this does not overflow, and value is at most type(uint160).max\\n            (bool s, uint256 v) = _tryParseHexUintUncheckedBounds(input, begin, end);\\n            return (s, address(uint160(v)));\\n        } else {\\n            return (false, address(0));\\n        }\\n    }\\n\\n    function _tryParseChr(bytes1 chr) private pure returns (uint8) {\\n        uint8 value = uint8(chr);\\n\\n        // Try to parse `chr`:\\n        // - Case 1: [0-9]\\n        // - Case 2: [a-f]\\n        // - Case 3: [A-F]\\n        // - otherwise not supported\\n        unchecked {\\n            if (value > 47 && value < 58) value -= 48;\\n            else if (value > 96 && value < 103) value -= 87;\\n            else if (value > 64 && value < 71) value -= 55;\\n            else return type(uint8).max;\\n        }\\n\\n        return value;\\n    }\\n\\n    /**\\n     * @dev Escape special characters in JSON strings. This can be useful to prevent JSON injection in NFT metadata.\\n     *\\n     * WARNING: This function should only be used in double quoted JSON strings. Single quotes are not escaped.\\n     *\\n     * NOTE: This function escapes all unicode characters, and not just the ones in ranges defined in section 2.5 of\\n     * RFC-4627 (U+0000 to U+001F, U+0022 and U+005C). ECMAScript's `JSON.parse` does recover escaped unicode\\n     * characters that are not in this range, but other tooling may provide different results.\\n     */\\n    function escapeJSON(string memory input) internal pure returns (string memory) {\\n        bytes memory buffer = bytes(input);\\n        bytes memory output = new bytes(2 * buffer.length); // worst case scenario\\n        uint256 outputLength = 0;\\n\\n        for (uint256 i; i < buffer.length; ++i) {\\n            bytes1 char = bytes1(_unsafeReadBytesOffset(buffer, i));\\n            if (((SPECIAL_CHARS_LOOKUP & (1 << uint8(char))) != 0)) {\\n                output[outputLength++] = \\\"\\\\\\\\\\\";\\n                if (char == 0x08) output[outputLength++] = \\\"b\\\";\\n                else if (char == 0x09) output[outputLength++] = \\\"t\\\";\\n                else if (char == 0x0a) output[outputLength++] = \\\"n\\\";\\n                else if (char == 0x0c) output[outputLength++] = \\\"f\\\";\\n                else if (char == 0x0d) output[outputLength++] = \\\"r\\\";\\n                else if (char == 0x5c) output[outputLength++] = \\\"\\\\\\\\\\\";\\n                else if (char == 0x22) {\\n                    // solhint-disable-next-line quotes\\n                    output[outputLength++] = '\\\"';\\n                }\\n            } else {\\n                output[outputLength++] = char;\\n            }\\n        }\\n        // write the actual length and deallocate unused memory\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(output, outputLength)\\n            mstore(0x40, add(output, shl(5, shr(5, add(outputLength, 63)))))\\n        }\\n\\n        return string(output);\\n    }\\n\\n    /**\\n     * @dev Reads a bytes32 from a bytes array without bounds checking.\\n     *\\n     * NOTE: making this function internal would mean it could be used with memory unsafe offset, and marking the\\n     * assembly block as such would prevent some optimizations.\\n     */\\n    function _unsafeReadBytesOffset(bytes memory buffer, uint256 offset) private pure returns (bytes32 value) {\\n        // This is not memory safe in the general case, but all calls to this private function are within bounds.\\n        assembly (\\\"memory-safe\\\") {\\n            value := mload(add(buffer, add(0x20, offset)))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x81c274a60a7ae232ae3dc9ff3a4011b4849a853c13b0832cd3351bb1bb2f0dae\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/ECDSA.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/cryptography/ECDSA.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.\\n *\\n * These functions can be used to verify that a message was signed by the holder\\n * of the private keys of a given address.\\n */\\nlibrary ECDSA {\\n    enum RecoverError {\\n        NoError,\\n        InvalidSignature,\\n        InvalidSignatureLength,\\n        InvalidSignatureS\\n    }\\n\\n    /**\\n     * @dev The signature derives the `address(0)`.\\n     */\\n    error ECDSAInvalidSignature();\\n\\n    /**\\n     * @dev The signature has an invalid length.\\n     */\\n    error ECDSAInvalidSignatureLength(uint256 length);\\n\\n    /**\\n     * @dev The signature has an S value that is in the upper half order.\\n     */\\n    error ECDSAInvalidSignatureS(bytes32 s);\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with `signature` or an error. This will not\\n     * return address(0) without also returning an error description. Errors are documented using an enum (error type)\\n     * and a bytes32 providing additional information about the error.\\n     *\\n     * If no error is returned, then the address can be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     *\\n     * Documentation for signature generation:\\n     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]\\n     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes memory signature\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        if (signature.length == 65) {\\n            bytes32 r;\\n            bytes32 s;\\n            uint8 v;\\n            // ecrecover takes the signature parameters, and the only way to get them\\n            // currently is to use assembly.\\n            assembly (\\\"memory-safe\\\") {\\n                r := mload(add(signature, 0x20))\\n                s := mload(add(signature, 0x40))\\n                v := byte(0, mload(add(signature, 0x60)))\\n            }\\n            return tryRecover(hash, v, r, s);\\n        } else {\\n            return (address(0), RecoverError.InvalidSignatureLength, bytes32(signature.length));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the address that signed a hashed message (`hash`) with\\n     * `signature`. This address can then be used for verification purposes.\\n     *\\n     * The `ecrecover` EVM precompile allows for malleable (non-unique) signatures:\\n     * this function rejects them by requiring the `s` value to be in the lower\\n     * half order, and the `v` value to be either 27 or 28.\\n     *\\n     * IMPORTANT: `hash` _must_ be the result of a hash operation for the\\n     * verification to be secure: it is possible to craft signatures that\\n     * recover to arbitrary addresses for non-hashed data. A safe way to ensure\\n     * this is by receiving a hash of the original message (which may otherwise\\n     * be too long), and then calling {MessageHashUtils-toEthSignedMessageHash} on it.\\n     */\\n    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, signature);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `r` and `vs` short-signature fields separately.\\n     *\\n     * See https://eips.ethereum.org/EIPS/eip-2098[ERC-2098 short signatures]\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        bytes32 r,\\n        bytes32 vs\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        unchecked {\\n            bytes32 s = vs & bytes32(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);\\n            // We do not check for an overflow here since the shift operation results in 0 or 1.\\n            uint8 v = uint8((uint256(vs) >> 255) + 27);\\n            return tryRecover(hash, v, r, s);\\n        }\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `r and `vs` short-signature fields separately.\\n     */\\n    function recover(bytes32 hash, bytes32 r, bytes32 vs) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, r, vs);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-tryRecover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function tryRecover(\\n        bytes32 hash,\\n        uint8 v,\\n        bytes32 r,\\n        bytes32 s\\n    ) internal pure returns (address recovered, RecoverError err, bytes32 errArg) {\\n        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature\\n        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines\\n        // the valid range for s in (301): 0 < s < secp256k1n \\u00f7 2 + 1, and for v in (302): v \\u2208 {27, 28}. Most\\n        // signatures from current libraries generate a unique signature with an s-value in the lower half order.\\n        //\\n        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value\\n        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or\\n        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept\\n        // these malleable signatures as well.\\n        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {\\n            return (address(0), RecoverError.InvalidSignatureS, s);\\n        }\\n\\n        // If the signature is valid (and not malleable), return the signer address\\n        address signer = ecrecover(hash, v, r, s);\\n        if (signer == address(0)) {\\n            return (address(0), RecoverError.InvalidSignature, bytes32(0));\\n        }\\n\\n        return (signer, RecoverError.NoError, bytes32(0));\\n    }\\n\\n    /**\\n     * @dev Overload of {ECDSA-recover} that receives the `v`,\\n     * `r` and `s` signature fields separately.\\n     */\\n    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {\\n        (address recovered, RecoverError error, bytes32 errorArg) = tryRecover(hash, v, r, s);\\n        _throwError(error, errorArg);\\n        return recovered;\\n    }\\n\\n    /**\\n     * @dev Optionally reverts with the corresponding custom error according to the `error` argument provided.\\n     */\\n    function _throwError(RecoverError error, bytes32 errorArg) private pure {\\n        if (error == RecoverError.NoError) {\\n            return; // no error: do nothing\\n        } else if (error == RecoverError.InvalidSignature) {\\n            revert ECDSAInvalidSignature();\\n        } else if (error == RecoverError.InvalidSignatureLength) {\\n            revert ECDSAInvalidSignatureLength(uint256(errorArg));\\n        } else if (error == RecoverError.InvalidSignatureS) {\\n            revert ECDSAInvalidSignatureS(errorArg);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/EIP712.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/EIP712.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {MessageHashUtils} from \\\"./MessageHashUtils.sol\\\";\\nimport {ShortStrings, ShortString} from \\\"../ShortStrings.sol\\\";\\nimport {IERC5267} from \\\"../../interfaces/IERC5267.sol\\\";\\n\\n/**\\n * @dev https://eips.ethereum.org/EIPS/eip-712[EIP-712] is a standard for hashing and signing of typed structured data.\\n *\\n * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose\\n * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract\\n * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to\\n * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.\\n *\\n * This contract implements the EIP-712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding\\n * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA\\n * ({_hashTypedDataV4}).\\n *\\n * The implementation of the domain separator was designed to be as efficient as possible while still properly updating\\n * the chain id to protect against replay attacks on an eventual fork of the chain.\\n *\\n * NOTE: This contract implements the version of the encoding known as \\\"v4\\\", as implemented by the JSON RPC method\\n * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].\\n *\\n * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain\\n * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the\\n * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.\\n *\\n * @custom:oz-upgrades-unsafe-allow state-variable-immutable\\n */\\nabstract contract EIP712 is IERC5267 {\\n    using ShortStrings for *;\\n\\n    bytes32 private constant TYPE_HASH =\\n        keccak256(\\\"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)\\\");\\n\\n    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to\\n    // invalidate the cached domain separator if the chain id changes.\\n    bytes32 private immutable _cachedDomainSeparator;\\n    uint256 private immutable _cachedChainId;\\n    address private immutable _cachedThis;\\n\\n    bytes32 private immutable _hashedName;\\n    bytes32 private immutable _hashedVersion;\\n\\n    ShortString private immutable _name;\\n    ShortString private immutable _version;\\n    // slither-disable-next-line constable-states\\n    string private _nameFallback;\\n    // slither-disable-next-line constable-states\\n    string private _versionFallback;\\n\\n    /**\\n     * @dev Initializes the domain separator and parameter caches.\\n     *\\n     * The meaning of `name` and `version` is specified in\\n     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP-712]:\\n     *\\n     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.\\n     * - `version`: the current major version of the signing domain.\\n     *\\n     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart\\n     * contract upgrade].\\n     */\\n    constructor(string memory name, string memory version) {\\n        _name = name.toShortStringWithFallback(_nameFallback);\\n        _version = version.toShortStringWithFallback(_versionFallback);\\n        _hashedName = keccak256(bytes(name));\\n        _hashedVersion = keccak256(bytes(version));\\n\\n        _cachedChainId = block.chainid;\\n        _cachedDomainSeparator = _buildDomainSeparator();\\n        _cachedThis = address(this);\\n    }\\n\\n    /**\\n     * @dev Returns the domain separator for the current chain.\\n     */\\n    function _domainSeparatorV4() internal view returns (bytes32) {\\n        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {\\n            return _cachedDomainSeparator;\\n        } else {\\n            return _buildDomainSeparator();\\n        }\\n    }\\n\\n    function _buildDomainSeparator() private view returns (bytes32) {\\n        return keccak256(abi.encode(TYPE_HASH, _hashedName, _hashedVersion, block.chainid, address(this)));\\n    }\\n\\n    /**\\n     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this\\n     * function returns the hash of the fully encoded EIP712 message for this domain.\\n     *\\n     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:\\n     *\\n     * ```solidity\\n     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(\\n     *     keccak256(\\\"Mail(address to,string contents)\\\"),\\n     *     mailTo,\\n     *     keccak256(bytes(mailContents))\\n     * )));\\n     * address signer = ECDSA.recover(digest, signature);\\n     * ```\\n     */\\n    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {\\n        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);\\n    }\\n\\n    /**\\n     * @inheritdoc IERC5267\\n     */\\n    function eip712Domain()\\n        public\\n        view\\n        virtual\\n        returns (\\n            bytes1 fields,\\n            string memory name,\\n            string memory version,\\n            uint256 chainId,\\n            address verifyingContract,\\n            bytes32 salt,\\n            uint256[] memory extensions\\n        )\\n    {\\n        return (\\n            hex\\\"0f\\\", // 01111\\n            _EIP712Name(),\\n            _EIP712Version(),\\n            block.chainid,\\n            address(this),\\n            bytes32(0),\\n            new uint256[](0)\\n        );\\n    }\\n\\n    /**\\n     * @dev The name parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _name which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Name() internal view returns (string memory) {\\n        return _name.toStringWithFallback(_nameFallback);\\n    }\\n\\n    /**\\n     * @dev The version parameter for the EIP712 domain.\\n     *\\n     * NOTE: By default this function reads _version which is an immutable value.\\n     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).\\n     */\\n    // solhint-disable-next-line func-name-mixedcase\\n    function _EIP712Version() internal view returns (string memory) {\\n        return _version.toStringWithFallback(_versionFallback);\\n    }\\n}\\n\",\"keccak256\":\"0x0c60057e7351874f086db8dc9291b7ada9ad62cb7725befd2991430d04a74572\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/cryptography/MessageHashUtils.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Strings} from \\\"../Strings.sol\\\";\\n\\n/**\\n * @dev Signature message hash utilities for producing digests to be consumed by {ECDSA} recovery or signing.\\n *\\n * The library provides methods for generating a hash of a message that conforms to the\\n * https://eips.ethereum.org/EIPS/eip-191[ERC-191] and https://eips.ethereum.org/EIPS/eip-712[EIP 712]\\n * specifications.\\n */\\nlibrary MessageHashUtils {\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing a bytes32 `messageHash` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n32\\\"` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * NOTE: The `messageHash` parameter is intended to be the result of hashing a raw message with\\n     * keccak256, although any bytes32 value can be safely used because the final digest will\\n     * be re-hashed.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes32 messageHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, \\\"\\\\x19Ethereum Signed Message:\\\\n32\\\") // 32 is the bytes-length of messageHash\\n            mstore(0x1c, messageHash) // 0x1c (28) is the length of the prefix\\n            digest := keccak256(0x00, 0x3c) // 0x3c is the length of the prefix (0x1c) + messageHash (0x20)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x45` (`personal_sign` messages).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `message` with\\n     * `\\\"\\\\x19Ethereum Signed Message:\\\\n\\\" + len(message)` and hashing the result. It corresponds with the\\n     * hash signed when using the https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign[`eth_sign`] JSON-RPC method.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toEthSignedMessageHash(bytes memory message) internal pure returns (bytes32) {\\n        return\\n            keccak256(bytes.concat(\\\"\\\\x19Ethereum Signed Message:\\\\n\\\", bytes(Strings.toString(message.length)), message));\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an ERC-191 signed data with version\\n     * `0x00` (data with intended validator).\\n     *\\n     * The digest is calculated by prefixing an arbitrary `data` with `\\\"\\\\x19\\\\x00\\\"` and the intended\\n     * `validator` address. Then hashing the result.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toDataWithIntendedValidatorHash(address validator, bytes memory data) internal pure returns (bytes32) {\\n        return keccak256(abi.encodePacked(hex\\\"19_00\\\", validator, data));\\n    }\\n\\n    /**\\n     * @dev Variant of {toDataWithIntendedValidatorHash-address-bytes} optimized for cases where `data` is a bytes32.\\n     */\\n    function toDataWithIntendedValidatorHash(\\n        address validator,\\n        bytes32 messageHash\\n    ) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            mstore(0x00, hex\\\"19_00\\\")\\n            mstore(0x02, shl(96, validator))\\n            mstore(0x16, messageHash)\\n            digest := keccak256(0x00, 0x36)\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the keccak256 digest of an EIP-712 typed data (ERC-191 version `0x01`).\\n     *\\n     * The digest is calculated from a `domainSeparator` and a `structHash`, by prefixing them with\\n     * `\\\\x19\\\\x01` and hashing the result. It corresponds to the hash signed by the\\n     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`] JSON-RPC method as part of EIP-712.\\n     *\\n     * See {ECDSA-recover}.\\n     */\\n    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32 digest) {\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            mstore(ptr, hex\\\"19_01\\\")\\n            mstore(add(ptr, 0x02), domainSeparator)\\n            mstore(add(ptr, 0x22), structHash)\\n            digest := keccak256(ptr, 0x42)\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/introspection/IERC165.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/introspection/IERC165.sol)\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Interface of the ERC-165 standard, as defined in the\\n * https://eips.ethereum.org/EIPS/eip-165[ERC].\\n *\\n * Implementers can declare support of contract interfaces, which can then be\\n * queried by others ({ERC165Checker}).\\n *\\n * For an implementation, see {ERC165}.\\n */\\ninterface IERC165 {\\n    /**\\n     * @dev Returns true if this contract implements the interface defined by\\n     * `interfaceId`. See the corresponding\\n     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section]\\n     * to learn more about how these ids are created.\\n     *\\n     * This function call must use less than 30 000 gas.\\n     */\\n    function supportsInterface(bytes4 interfaceId) external view returns (bool);\\n}\\n\",\"keccak256\":\"0x79796192ec90263f21b464d5bc90b777a525971d3de8232be80d9c4f9fb353b8\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/Math.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.3.0) (utils/math/Math.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {Panic} from \\\"../Panic.sol\\\";\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard math utilities missing in the Solidity language.\\n */\\nlibrary Math {\\n    enum Rounding {\\n        Floor, // Toward negative infinity\\n        Ceil, // Toward positive infinity\\n        Trunc, // Toward zero\\n        Expand // Away from zero\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit addition of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that sum = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function add512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        assembly (\\\"memory-safe\\\") {\\n            low := add(a, b)\\n            high := lt(low, a)\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the 512-bit multiplication of two uint256.\\n     *\\n     * The result is stored in two 256 variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n     */\\n    function mul512(uint256 a, uint256 b) internal pure returns (uint256 high, uint256 low) {\\n        // 512-bit multiply [high low] = x * y. Compute the product mod 2\\u00b2\\u2075\\u2076 and mod 2\\u00b2\\u2075\\u2076 - 1, then use\\n        // the Chinese Remainder Theorem to reconstruct the 512 bit result. The result is stored in two 256\\n        // variables such that product = high * 2\\u00b2\\u2075\\u2076 + low.\\n        assembly (\\\"memory-safe\\\") {\\n            let mm := mulmod(a, b, not(0))\\n            low := mul(a, b)\\n            high := sub(sub(mm, low), lt(mm, low))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the addition of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryAdd(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a + b;\\n            success = c >= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the subtraction of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function trySub(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a - b;\\n            success = c <= a;\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the multiplication of two unsigned integers, with a success flag (no overflow).\\n     */\\n    function tryMul(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            uint256 c = a * b;\\n            assembly (\\\"memory-safe\\\") {\\n                // Only true when the multiplication doesn't overflow\\n                // (c / a == b) || (a == 0)\\n                success := or(eq(div(c, a), b), iszero(a))\\n            }\\n            // equivalent to: success ? c : 0\\n            result = c * SafeCast.toUint(success);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the division of two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryDiv(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `DIV` opcode returns zero when the denominator is 0.\\n                result := div(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the remainder of dividing two unsigned integers, with a success flag (no division by zero).\\n     */\\n    function tryMod(uint256 a, uint256 b) internal pure returns (bool success, uint256 result) {\\n        unchecked {\\n            success = b > 0;\\n            assembly (\\\"memory-safe\\\") {\\n                // The `MOD` opcode returns zero when the denominator is 0.\\n                result := mod(a, b)\\n            }\\n        }\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating addition, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingAdd(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryAdd(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating subtraction, bounds to zero instead of overflowing.\\n     */\\n    function saturatingSub(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (, uint256 result) = trySub(a, b);\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Unsigned saturating multiplication, bounds to `2\\u00b2\\u2075\\u2076 - 1` instead of overflowing.\\n     */\\n    function saturatingMul(uint256 a, uint256 b) internal pure returns (uint256) {\\n        (bool success, uint256 result) = tryMul(a, b);\\n        return ternary(success, result, type(uint256).max);\\n    }\\n\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, uint256 a, uint256 b) internal pure returns (uint256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * SafeCast.toUint(condition));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two numbers.\\n     */\\n    function max(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two numbers.\\n     */\\n    function min(uint256 a, uint256 b) internal pure returns (uint256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two numbers. The result is rounded towards\\n     * zero.\\n     */\\n    function average(uint256 a, uint256 b) internal pure returns (uint256) {\\n        // (a + b) / 2 can overflow.\\n        return (a & b) + (a ^ b) / 2;\\n    }\\n\\n    /**\\n     * @dev Returns the ceiling of the division of two numbers.\\n     *\\n     * This differs from standard division with `/` in that it rounds towards infinity instead\\n     * of rounding towards zero.\\n     */\\n    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {\\n        if (b == 0) {\\n            // Guarantee the same behavior as in a regular Solidity division.\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n\\n        // The following calculation ensures accurate ceiling division without overflow.\\n        // Since a is non-zero, (a - 1) / b will not overflow.\\n        // The largest possible result occurs when (a - 1) / b is type(uint256).max,\\n        // but the largest value we can obtain is type(uint256).max - 1, which happens\\n        // when a = type(uint256).max and b = 1.\\n        unchecked {\\n            return SafeCast.toUint(a > 0) * ((a - 1) / b + 1);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or\\n     * denominator == 0.\\n     *\\n     * Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv) with further edits by\\n     * Uniswap Labs also under MIT license.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n\\n            // Handle non-overflow cases, 256 by 256 division.\\n            if (high == 0) {\\n                // Solidity will revert if denominator == 0, unlike the div opcode on its own.\\n                // The surrounding unchecked block does not change this fact.\\n                // See https://docs.soliditylang.org/en/latest/control-structures.html#checked-or-unchecked-arithmetic.\\n                return low / denominator;\\n            }\\n\\n            // Make sure the result is less than 2\\u00b2\\u2075\\u2076. Also prevents denominator == 0.\\n            if (denominator <= high) {\\n                Panic.panic(ternary(denominator == 0, Panic.DIVISION_BY_ZERO, Panic.UNDER_OVERFLOW));\\n            }\\n\\n            ///////////////////////////////////////////////\\n            // 512 by 256 division.\\n            ///////////////////////////////////////////////\\n\\n            // Make division exact by subtracting the remainder from [high low].\\n            uint256 remainder;\\n            assembly (\\\"memory-safe\\\") {\\n                // Compute remainder using mulmod.\\n                remainder := mulmod(x, y, denominator)\\n\\n                // Subtract 256 bit number from 512 bit number.\\n                high := sub(high, gt(remainder, low))\\n                low := sub(low, remainder)\\n            }\\n\\n            // Factor powers of two out of denominator and compute largest power of two divisor of denominator.\\n            // Always >= 1. See https://cs.stackexchange.com/q/138556/92363.\\n\\n            uint256 twos = denominator & (0 - denominator);\\n            assembly (\\\"memory-safe\\\") {\\n                // Divide denominator by twos.\\n                denominator := div(denominator, twos)\\n\\n                // Divide [high low] by twos.\\n                low := div(low, twos)\\n\\n                // Flip twos such that it is 2\\u00b2\\u2075\\u2076 / twos. If twos is zero, then it becomes one.\\n                twos := add(div(sub(0, twos), twos), 1)\\n            }\\n\\n            // Shift in bits from high into low.\\n            low |= high * twos;\\n\\n            // Invert denominator mod 2\\u00b2\\u2075\\u2076. Now that denominator is an odd number, it has an inverse modulo 2\\u00b2\\u2075\\u2076 such\\n            // that denominator * inv \\u2261 1 mod 2\\u00b2\\u2075\\u2076. Compute the inverse by starting with a seed that is correct for\\n            // four bits. That is, denominator * inv \\u2261 1 mod 2\\u2074.\\n            uint256 inverse = (3 * denominator) ^ 2;\\n\\n            // Use the Newton-Raphson iteration to improve the precision. Thanks to Hensel's lifting lemma, this also\\n            // works in modular arithmetic, doubling the correct bits in each step.\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u2076\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b3\\u00b2\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u2076\\u2074\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b9\\u00b2\\u2078\\n            inverse *= 2 - denominator * inverse; // inverse mod 2\\u00b2\\u2075\\u2076\\n\\n            // Because the division is now exact we can divide by multiplying with the modular inverse of denominator.\\n            // This will give us the correct result modulo 2\\u00b2\\u2075\\u2076. Since the preconditions guarantee that the outcome is\\n            // less than 2\\u00b2\\u2075\\u2076, this is the final result. We don't need to compute the high bits of the result and high\\n            // is no longer required.\\n            result = low * inverse;\\n            return result;\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y / denominator with full precision, following the selected rounding direction.\\n     */\\n    function mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding) internal pure returns (uint256) {\\n        return mulDiv(x, y, denominator) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, denominator) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculates floor(x * y >> n) with full precision. Throws if result overflows a uint256.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n) internal pure returns (uint256 result) {\\n        unchecked {\\n            (uint256 high, uint256 low) = mul512(x, y);\\n            if (high >= 1 << n) {\\n                Panic.panic(Panic.UNDER_OVERFLOW);\\n            }\\n            return (high << (256 - n)) | (low >> n);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates x * y >> n with full precision, following the selected rounding direction.\\n     */\\n    function mulShr(uint256 x, uint256 y, uint8 n, Rounding rounding) internal pure returns (uint256) {\\n        return mulShr(x, y, n) + SafeCast.toUint(unsignedRoundsUp(rounding) && mulmod(x, y, 1 << n) > 0);\\n    }\\n\\n    /**\\n     * @dev Calculate the modular multiplicative inverse of a number in Z/nZ.\\n     *\\n     * If n is a prime, then Z/nZ is a field. In that case all elements are inversible, except 0.\\n     * If n is not a prime, then Z/nZ is not a field, and some elements might not be inversible.\\n     *\\n     * If the input value is not inversible, 0 is returned.\\n     *\\n     * NOTE: If you know for sure that n is (big) a prime, it may be cheaper to use Fermat's little theorem and get the\\n     * inverse using `Math.modExp(a, n - 2, n)`. See {invModPrime}.\\n     */\\n    function invMod(uint256 a, uint256 n) internal pure returns (uint256) {\\n        unchecked {\\n            if (n == 0) return 0;\\n\\n            // The inverse modulo is calculated using the Extended Euclidean Algorithm (iterative version)\\n            // Used to compute integers x and y such that: ax + ny = gcd(a, n).\\n            // When the gcd is 1, then the inverse of a modulo n exists and it's x.\\n            // ax + ny = 1\\n            // ax = 1 + (-y)n\\n            // ax \\u2261 1 (mod n) # x is the inverse of a modulo n\\n\\n            // If the remainder is 0 the gcd is n right away.\\n            uint256 remainder = a % n;\\n            uint256 gcd = n;\\n\\n            // Therefore the initial coefficients are:\\n            // ax + ny = gcd(a, n) = n\\n            // 0a + 1n = n\\n            int256 x = 0;\\n            int256 y = 1;\\n\\n            while (remainder != 0) {\\n                uint256 quotient = gcd / remainder;\\n\\n                (gcd, remainder) = (\\n                    // The old remainder is the next gcd to try.\\n                    remainder,\\n                    // Compute the next remainder.\\n                    // Can't overflow given that (a % gcd) * (gcd // (a % gcd)) <= gcd\\n                    // where gcd is at most n (capped to type(uint256).max)\\n                    gcd - remainder * quotient\\n                );\\n\\n                (x, y) = (\\n                    // Increment the coefficient of a.\\n                    y,\\n                    // Decrement the coefficient of n.\\n                    // Can overflow, but the result is casted to uint256 so that the\\n                    // next value of y is \\\"wrapped around\\\" to a value between 0 and n - 1.\\n                    x - y * int256(quotient)\\n                );\\n            }\\n\\n            if (gcd != 1) return 0; // No inverse exists.\\n            return ternary(x < 0, n - uint256(-x), uint256(x)); // Wrap the result if it's negative.\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {invMod}. More efficient, but only works if `p` is known to be a prime greater than `2`.\\n     *\\n     * From https://en.wikipedia.org/wiki/Fermat%27s_little_theorem[Fermat's little theorem], we know that if p is\\n     * prime, then `a**(p-1) \\u2261 1 mod p`. As a consequence, we have `a * a**(p-2) \\u2261 1 mod p`, which means that\\n     * `a**(p-2)` is the modular multiplicative inverse of a in Fp.\\n     *\\n     * NOTE: this function does NOT check that `p` is a prime greater than `2`.\\n     */\\n    function invModPrime(uint256 a, uint256 p) internal view returns (uint256) {\\n        unchecked {\\n            return Math.modExp(a, p - 2, p);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m)\\n     *\\n     * Requirements:\\n     * - modulus can't be zero\\n     * - underlying staticcall to precompile must succeed\\n     *\\n     * IMPORTANT: The result is only valid if the underlying call succeeds. When using this function, make\\n     * sure the chain you're using it on supports the precompiled contract for modular exponentiation\\n     * at address 0x05 as specified in https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise,\\n     * the underlying function will succeed given the lack of a revert, but the result may be incorrectly\\n     * interpreted as 0.\\n     */\\n    function modExp(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {\\n        (bool success, uint256 result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Returns the modular exponentiation of the specified base, exponent and modulus (b ** e % m).\\n     * It includes a success flag indicating if the operation succeeded. Operation will be marked as failed if trying\\n     * to operate modulo 0 or if the underlying precompile reverted.\\n     *\\n     * IMPORTANT: The result is only valid if the success flag is true. When using this function, make sure the chain\\n     * you're using it on supports the precompiled contract for modular exponentiation at address 0x05 as specified in\\n     * https://eips.ethereum.org/EIPS/eip-198[EIP-198]. Otherwise, the underlying function will succeed given the lack\\n     * of a revert, but the result may be incorrectly interpreted as 0.\\n     */\\n    function tryModExp(uint256 b, uint256 e, uint256 m) internal view returns (bool success, uint256 result) {\\n        if (m == 0) return (false, 0);\\n        assembly (\\\"memory-safe\\\") {\\n            let ptr := mload(0x40)\\n            // | Offset    | Content    | Content (Hex)                                                      |\\n            // |-----------|------------|--------------------------------------------------------------------|\\n            // | 0x00:0x1f | size of b  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x20:0x3f | size of e  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x40:0x5f | size of m  | 0x0000000000000000000000000000000000000000000000000000000000000020 |\\n            // | 0x60:0x7f | value of b | 0x<.............................................................b> |\\n            // | 0x80:0x9f | value of e | 0x<.............................................................e> |\\n            // | 0xa0:0xbf | value of m | 0x<.............................................................m> |\\n            mstore(ptr, 0x20)\\n            mstore(add(ptr, 0x20), 0x20)\\n            mstore(add(ptr, 0x40), 0x20)\\n            mstore(add(ptr, 0x60), b)\\n            mstore(add(ptr, 0x80), e)\\n            mstore(add(ptr, 0xa0), m)\\n\\n            // Given the result < m, it's guaranteed to fit in 32 bytes,\\n            // so we can use the memory scratch space located at offset 0.\\n            success := staticcall(gas(), 0x05, ptr, 0xc0, 0x00, 0x20)\\n            result := mload(0x00)\\n        }\\n    }\\n\\n    /**\\n     * @dev Variant of {modExp} that supports inputs of arbitrary length.\\n     */\\n    function modExp(bytes memory b, bytes memory e, bytes memory m) internal view returns (bytes memory) {\\n        (bool success, bytes memory result) = tryModExp(b, e, m);\\n        if (!success) {\\n            Panic.panic(Panic.DIVISION_BY_ZERO);\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Variant of {tryModExp} that supports inputs of arbitrary length.\\n     */\\n    function tryModExp(\\n        bytes memory b,\\n        bytes memory e,\\n        bytes memory m\\n    ) internal view returns (bool success, bytes memory result) {\\n        if (_zeroBytes(m)) return (false, new bytes(0));\\n\\n        uint256 mLen = m.length;\\n\\n        // Encode call args in result and move the free memory pointer\\n        result = abi.encodePacked(b.length, e.length, mLen, b, e, m);\\n\\n        assembly (\\\"memory-safe\\\") {\\n            let dataPtr := add(result, 0x20)\\n            // Write result on top of args to avoid allocating extra memory.\\n            success := staticcall(gas(), 0x05, dataPtr, mload(result), dataPtr, mLen)\\n            // Overwrite the length.\\n            // result.length > returndatasize() is guaranteed because returndatasize() == m.length\\n            mstore(result, mLen)\\n            // Set the memory pointer after the returned data.\\n            mstore(0x40, add(dataPtr, mLen))\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether the provided byte array is zero.\\n     */\\n    function _zeroBytes(bytes memory byteArray) private pure returns (bool) {\\n        for (uint256 i = 0; i < byteArray.length; ++i) {\\n            if (byteArray[i] != 0) {\\n                return false;\\n            }\\n        }\\n        return true;\\n    }\\n\\n    /**\\n     * @dev Returns the square root of a number. If the number is not a perfect square, the value is rounded\\n     * towards zero.\\n     *\\n     * This method is based on Newton's method for computing square roots; the algorithm is restricted to only\\n     * using integer operations.\\n     */\\n    function sqrt(uint256 a) internal pure returns (uint256) {\\n        unchecked {\\n            // Take care of easy edge cases when a == 0 or a == 1\\n            if (a <= 1) {\\n                return a;\\n            }\\n\\n            // In this function, we use Newton's method to get a root of `f(x) := x\\u00b2 - a`. It involves building a\\n            // sequence x_n that converges toward sqrt(a). For each iteration x_n, we also define the error between\\n            // the current value as `\\u03b5_n = | x_n - sqrt(a) |`.\\n            //\\n            // For our first estimation, we consider `e` the smallest power of 2 which is bigger than the square root\\n            // of the target. (i.e. `2**(e-1) \\u2264 sqrt(a) < 2**e`). We know that `e \\u2264 128` because `(2\\u00b9\\u00b2\\u2078)\\u00b2 = 2\\u00b2\\u2075\\u2076` is\\n            // bigger than any uint256.\\n            //\\n            // By noticing that\\n            // `2**(e-1) \\u2264 sqrt(a) < 2**e \\u2192 (2**(e-1))\\u00b2 \\u2264 a < (2**e)\\u00b2 \\u2192 2**(2*e-2) \\u2264 a < 2**(2*e)`\\n            // we can deduce that `e - 1` is `log2(a) / 2`. We can thus compute `x_n = 2**(e-1)` using a method similar\\n            // to the msb function.\\n            uint256 aa = a;\\n            uint256 xn = 1;\\n\\n            if (aa >= (1 << 128)) {\\n                aa >>= 128;\\n                xn <<= 64;\\n            }\\n            if (aa >= (1 << 64)) {\\n                aa >>= 64;\\n                xn <<= 32;\\n            }\\n            if (aa >= (1 << 32)) {\\n                aa >>= 32;\\n                xn <<= 16;\\n            }\\n            if (aa >= (1 << 16)) {\\n                aa >>= 16;\\n                xn <<= 8;\\n            }\\n            if (aa >= (1 << 8)) {\\n                aa >>= 8;\\n                xn <<= 4;\\n            }\\n            if (aa >= (1 << 4)) {\\n                aa >>= 4;\\n                xn <<= 2;\\n            }\\n            if (aa >= (1 << 2)) {\\n                xn <<= 1;\\n            }\\n\\n            // We now have x_n such that `x_n = 2**(e-1) \\u2264 sqrt(a) < 2**e = 2 * x_n`. This implies \\u03b5_n \\u2264 2**(e-1).\\n            //\\n            // We can refine our estimation by noticing that the middle of that interval minimizes the error.\\n            // If we move x_n to equal 2**(e-1) + 2**(e-2), then we reduce the error to \\u03b5_n \\u2264 2**(e-2).\\n            // This is going to be our x_0 (and \\u03b5_0)\\n            xn = (3 * xn) >> 1; // \\u03b5_0 := | x_0 - sqrt(a) | \\u2264 2**(e-2)\\n\\n            // From here, Newton's method give us:\\n            // x_{n+1} = (x_n + a / x_n) / 2\\n            //\\n            // One should note that:\\n            // x_{n+1}\\u00b2 - a = ((x_n + a / x_n) / 2)\\u00b2 - a\\n            //              = ((x_n\\u00b2 + a) / (2 * x_n))\\u00b2 - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2) - a\\n            //              = (x_n\\u2074 + 2 * a * x_n\\u00b2 + a\\u00b2 - 4 * a * x_n\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u2074 - 2 * a * x_n\\u00b2 + a\\u00b2) / (4 * x_n\\u00b2)\\n            //              = (x_n\\u00b2 - a)\\u00b2 / (2 * x_n)\\u00b2\\n            //              = ((x_n\\u00b2 - a) / (2 * x_n))\\u00b2\\n            //              \\u2265 0\\n            // Which proves that for all n \\u2265 1, sqrt(a) \\u2264 x_n\\n            //\\n            // This gives us the proof of quadratic convergence of the sequence:\\n            // \\u03b5_{n+1} = | x_{n+1} - sqrt(a) |\\n            //         = | (x_n + a / x_n) / 2 - sqrt(a) |\\n            //         = | (x_n\\u00b2 + a - 2*x_n*sqrt(a)) / (2 * x_n) |\\n            //         = | (x_n - sqrt(a))\\u00b2 / (2 * x_n) |\\n            //         = | \\u03b5_n\\u00b2 / (2 * x_n) |\\n            //         = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //\\n            // For the first iteration, we have a special case where x_0 is known:\\n            // \\u03b5_1 = \\u03b5_0\\u00b2 / | (2 * x_0) |\\n            //     \\u2264 (2**(e-2))\\u00b2 / (2 * (2**(e-1) + 2**(e-2)))\\n            //     \\u2264 2**(2*e-4) / (3 * 2**(e-1))\\n            //     \\u2264 2**(e-3) / 3\\n            //     \\u2264 2**(e-3-log2(3))\\n            //     \\u2264 2**(e-4.5)\\n            //\\n            // For the following iterations, we use the fact that, 2**(e-1) \\u2264 sqrt(a) \\u2264 x_n:\\n            // \\u03b5_{n+1} = \\u03b5_n\\u00b2 / | (2 * x_n) |\\n            //         \\u2264 (2**(e-k))\\u00b2 / (2 * 2**(e-1))\\n            //         \\u2264 2**(2*e-2*k) / 2**e\\n            //         \\u2264 2**(e-2*k)\\n            xn = (xn + a / xn) >> 1; // \\u03b5_1 := | x_1 - sqrt(a) | \\u2264 2**(e-4.5)  -- special case, see above\\n            xn = (xn + a / xn) >> 1; // \\u03b5_2 := | x_2 - sqrt(a) | \\u2264 2**(e-9)    -- general case with k = 4.5\\n            xn = (xn + a / xn) >> 1; // \\u03b5_3 := | x_3 - sqrt(a) | \\u2264 2**(e-18)   -- general case with k = 9\\n            xn = (xn + a / xn) >> 1; // \\u03b5_4 := | x_4 - sqrt(a) | \\u2264 2**(e-36)   -- general case with k = 18\\n            xn = (xn + a / xn) >> 1; // \\u03b5_5 := | x_5 - sqrt(a) | \\u2264 2**(e-72)   -- general case with k = 36\\n            xn = (xn + a / xn) >> 1; // \\u03b5_6 := | x_6 - sqrt(a) | \\u2264 2**(e-144)  -- general case with k = 72\\n\\n            // Because e \\u2264 128 (as discussed during the first estimation phase), we know have reached a precision\\n            // \\u03b5_6 \\u2264 2**(e-144) < 1. Given we're operating on integers, then we can ensure that xn is now either\\n            // sqrt(a) or sqrt(a) + 1.\\n            return xn - SafeCast.toUint(xn > a / xn);\\n        }\\n    }\\n\\n    /**\\n     * @dev Calculates sqrt(a), following the selected rounding direction.\\n     */\\n    function sqrt(uint256 a, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = sqrt(a);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && result * result < a);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // If upper 8 bits of 16-bit half set, add 8 to result\\n        r |= SafeCast.toUint((x >> r) > 0xff) << 3;\\n        // If upper 4 bits of 8-bit half set, add 4 to result\\n        r |= SafeCast.toUint((x >> r) > 0xf) << 2;\\n\\n        // Shifts value right by the current result and use it as an index into this lookup table:\\n        //\\n        // | x (4 bits) |  index  | table[index] = MSB position |\\n        // |------------|---------|-----------------------------|\\n        // |    0000    |    0    |        table[0] = 0         |\\n        // |    0001    |    1    |        table[1] = 0         |\\n        // |    0010    |    2    |        table[2] = 1         |\\n        // |    0011    |    3    |        table[3] = 1         |\\n        // |    0100    |    4    |        table[4] = 2         |\\n        // |    0101    |    5    |        table[5] = 2         |\\n        // |    0110    |    6    |        table[6] = 2         |\\n        // |    0111    |    7    |        table[7] = 2         |\\n        // |    1000    |    8    |        table[8] = 3         |\\n        // |    1001    |    9    |        table[9] = 3         |\\n        // |    1010    |   10    |        table[10] = 3        |\\n        // |    1011    |   11    |        table[11] = 3        |\\n        // |    1100    |   12    |        table[12] = 3        |\\n        // |    1101    |   13    |        table[13] = 3        |\\n        // |    1110    |   14    |        table[14] = 3        |\\n        // |    1111    |   15    |        table[15] = 3        |\\n        //\\n        // The lookup table is represented as a 32-byte value with the MSB positions for 0-15 in the last 16 bytes.\\n        assembly (\\\"memory-safe\\\") {\\n            r := or(r, byte(shr(r, x), 0x0000010102020202030303030303030300000000000000000000000000000000))\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 2, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log2(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log2(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value) internal pure returns (uint256) {\\n        uint256 result = 0;\\n        unchecked {\\n            if (value >= 10 ** 64) {\\n                value /= 10 ** 64;\\n                result += 64;\\n            }\\n            if (value >= 10 ** 32) {\\n                value /= 10 ** 32;\\n                result += 32;\\n            }\\n            if (value >= 10 ** 16) {\\n                value /= 10 ** 16;\\n                result += 16;\\n            }\\n            if (value >= 10 ** 8) {\\n                value /= 10 ** 8;\\n                result += 8;\\n            }\\n            if (value >= 10 ** 4) {\\n                value /= 10 ** 4;\\n                result += 4;\\n            }\\n            if (value >= 10 ** 2) {\\n                value /= 10 ** 2;\\n                result += 2;\\n            }\\n            if (value >= 10 ** 1) {\\n                result += 1;\\n            }\\n        }\\n        return result;\\n    }\\n\\n    /**\\n     * @dev Return the log in base 10, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log10(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log10(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 10 ** result < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256 of a positive value rounded towards zero.\\n     * Returns 0 if given 0.\\n     *\\n     * Adding one to the result gives the number of pairs of hex symbols needed to represent `value` as a hex string.\\n     */\\n    function log256(uint256 x) internal pure returns (uint256 r) {\\n        // If value has upper 128 bits set, log2 result is at least 128\\n        r = SafeCast.toUint(x > 0xffffffffffffffffffffffffffffffff) << 7;\\n        // If upper 64 bits of 128-bit half set, add 64 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffffffffffff) << 6;\\n        // If upper 32 bits of 64-bit half set, add 32 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffffffff) << 5;\\n        // If upper 16 bits of 32-bit half set, add 16 to result\\n        r |= SafeCast.toUint((x >> r) > 0xffff) << 4;\\n        // Add 1 if upper 8 bits of 16-bit half set, and divide accumulated result by 8\\n        return (r >> 3) | SafeCast.toUint((x >> r) > 0xff);\\n    }\\n\\n    /**\\n     * @dev Return the log in base 256, following the selected rounding direction, of a positive value.\\n     * Returns 0 if given 0.\\n     */\\n    function log256(uint256 value, Rounding rounding) internal pure returns (uint256) {\\n        unchecked {\\n            uint256 result = log256(value);\\n            return result + SafeCast.toUint(unsignedRoundsUp(rounding) && 1 << (result << 3) < value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns whether a provided rounding mode is considered rounding up for unsigned integers.\\n     */\\n    function unsignedRoundsUp(Rounding rounding) internal pure returns (bool) {\\n        return uint8(rounding) % 2 == 1;\\n    }\\n}\\n\",\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SafeCast.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SafeCast.sol)\\n// This file was procedurally generated from scripts/generate/templates/SafeCast.js.\\n\\npragma solidity ^0.8.20;\\n\\n/**\\n * @dev Wrappers over Solidity's uintXX/intXX/bool casting operators with added overflow\\n * checks.\\n *\\n * Downcasting from uint256/int256 in Solidity does not revert on overflow. This can\\n * easily result in undesired exploitation or bugs, since developers usually\\n * assume that overflows raise errors. `SafeCast` restores this intuition by\\n * reverting the transaction when such an operation overflows.\\n *\\n * Using this library instead of the unchecked operations eliminates an entire\\n * class of bugs, so it's recommended to use it always.\\n */\\nlibrary SafeCast {\\n    /**\\n     * @dev Value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);\\n\\n    /**\\n     * @dev An int value doesn't fit in an uint of `bits` size.\\n     */\\n    error SafeCastOverflowedIntToUint(int256 value);\\n\\n    /**\\n     * @dev Value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedIntDowncast(uint8 bits, int256 value);\\n\\n    /**\\n     * @dev An uint value doesn't fit in an int of `bits` size.\\n     */\\n    error SafeCastOverflowedUintToInt(uint256 value);\\n\\n    /**\\n     * @dev Returns the downcasted uint248 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint248).\\n     *\\n     * Counterpart to Solidity's `uint248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toUint248(uint256 value) internal pure returns (uint248) {\\n        if (value > type(uint248).max) {\\n            revert SafeCastOverflowedUintDowncast(248, value);\\n        }\\n        return uint248(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint240 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint240).\\n     *\\n     * Counterpart to Solidity's `uint240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toUint240(uint256 value) internal pure returns (uint240) {\\n        if (value > type(uint240).max) {\\n            revert SafeCastOverflowedUintDowncast(240, value);\\n        }\\n        return uint240(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint232 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint232).\\n     *\\n     * Counterpart to Solidity's `uint232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toUint232(uint256 value) internal pure returns (uint232) {\\n        if (value > type(uint232).max) {\\n            revert SafeCastOverflowedUintDowncast(232, value);\\n        }\\n        return uint232(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint224 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint224).\\n     *\\n     * Counterpart to Solidity's `uint224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toUint224(uint256 value) internal pure returns (uint224) {\\n        if (value > type(uint224).max) {\\n            revert SafeCastOverflowedUintDowncast(224, value);\\n        }\\n        return uint224(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint216 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint216).\\n     *\\n     * Counterpart to Solidity's `uint216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toUint216(uint256 value) internal pure returns (uint216) {\\n        if (value > type(uint216).max) {\\n            revert SafeCastOverflowedUintDowncast(216, value);\\n        }\\n        return uint216(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint208 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint208).\\n     *\\n     * Counterpart to Solidity's `uint208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toUint208(uint256 value) internal pure returns (uint208) {\\n        if (value > type(uint208).max) {\\n            revert SafeCastOverflowedUintDowncast(208, value);\\n        }\\n        return uint208(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint200 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint200).\\n     *\\n     * Counterpart to Solidity's `uint200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toUint200(uint256 value) internal pure returns (uint200) {\\n        if (value > type(uint200).max) {\\n            revert SafeCastOverflowedUintDowncast(200, value);\\n        }\\n        return uint200(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint192 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint192).\\n     *\\n     * Counterpart to Solidity's `uint192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toUint192(uint256 value) internal pure returns (uint192) {\\n        if (value > type(uint192).max) {\\n            revert SafeCastOverflowedUintDowncast(192, value);\\n        }\\n        return uint192(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint184 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint184).\\n     *\\n     * Counterpart to Solidity's `uint184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toUint184(uint256 value) internal pure returns (uint184) {\\n        if (value > type(uint184).max) {\\n            revert SafeCastOverflowedUintDowncast(184, value);\\n        }\\n        return uint184(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint176 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint176).\\n     *\\n     * Counterpart to Solidity's `uint176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toUint176(uint256 value) internal pure returns (uint176) {\\n        if (value > type(uint176).max) {\\n            revert SafeCastOverflowedUintDowncast(176, value);\\n        }\\n        return uint176(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint168 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint168).\\n     *\\n     * Counterpart to Solidity's `uint168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toUint168(uint256 value) internal pure returns (uint168) {\\n        if (value > type(uint168).max) {\\n            revert SafeCastOverflowedUintDowncast(168, value);\\n        }\\n        return uint168(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint160 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint160).\\n     *\\n     * Counterpart to Solidity's `uint160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toUint160(uint256 value) internal pure returns (uint160) {\\n        if (value > type(uint160).max) {\\n            revert SafeCastOverflowedUintDowncast(160, value);\\n        }\\n        return uint160(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint152 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint152).\\n     *\\n     * Counterpart to Solidity's `uint152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toUint152(uint256 value) internal pure returns (uint152) {\\n        if (value > type(uint152).max) {\\n            revert SafeCastOverflowedUintDowncast(152, value);\\n        }\\n        return uint152(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint144 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint144).\\n     *\\n     * Counterpart to Solidity's `uint144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toUint144(uint256 value) internal pure returns (uint144) {\\n        if (value > type(uint144).max) {\\n            revert SafeCastOverflowedUintDowncast(144, value);\\n        }\\n        return uint144(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint136 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint136).\\n     *\\n     * Counterpart to Solidity's `uint136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toUint136(uint256 value) internal pure returns (uint136) {\\n        if (value > type(uint136).max) {\\n            revert SafeCastOverflowedUintDowncast(136, value);\\n        }\\n        return uint136(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint128 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint128).\\n     *\\n     * Counterpart to Solidity's `uint128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toUint128(uint256 value) internal pure returns (uint128) {\\n        if (value > type(uint128).max) {\\n            revert SafeCastOverflowedUintDowncast(128, value);\\n        }\\n        return uint128(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint120 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint120).\\n     *\\n     * Counterpart to Solidity's `uint120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toUint120(uint256 value) internal pure returns (uint120) {\\n        if (value > type(uint120).max) {\\n            revert SafeCastOverflowedUintDowncast(120, value);\\n        }\\n        return uint120(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint112 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint112).\\n     *\\n     * Counterpart to Solidity's `uint112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toUint112(uint256 value) internal pure returns (uint112) {\\n        if (value > type(uint112).max) {\\n            revert SafeCastOverflowedUintDowncast(112, value);\\n        }\\n        return uint112(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint104 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint104).\\n     *\\n     * Counterpart to Solidity's `uint104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toUint104(uint256 value) internal pure returns (uint104) {\\n        if (value > type(uint104).max) {\\n            revert SafeCastOverflowedUintDowncast(104, value);\\n        }\\n        return uint104(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint96 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint96).\\n     *\\n     * Counterpart to Solidity's `uint96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toUint96(uint256 value) internal pure returns (uint96) {\\n        if (value > type(uint96).max) {\\n            revert SafeCastOverflowedUintDowncast(96, value);\\n        }\\n        return uint96(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint88 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint88).\\n     *\\n     * Counterpart to Solidity's `uint88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toUint88(uint256 value) internal pure returns (uint88) {\\n        if (value > type(uint88).max) {\\n            revert SafeCastOverflowedUintDowncast(88, value);\\n        }\\n        return uint88(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint80 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint80).\\n     *\\n     * Counterpart to Solidity's `uint80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toUint80(uint256 value) internal pure returns (uint80) {\\n        if (value > type(uint80).max) {\\n            revert SafeCastOverflowedUintDowncast(80, value);\\n        }\\n        return uint80(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint72 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint72).\\n     *\\n     * Counterpart to Solidity's `uint72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toUint72(uint256 value) internal pure returns (uint72) {\\n        if (value > type(uint72).max) {\\n            revert SafeCastOverflowedUintDowncast(72, value);\\n        }\\n        return uint72(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint64 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint64).\\n     *\\n     * Counterpart to Solidity's `uint64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toUint64(uint256 value) internal pure returns (uint64) {\\n        if (value > type(uint64).max) {\\n            revert SafeCastOverflowedUintDowncast(64, value);\\n        }\\n        return uint64(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint56 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint56).\\n     *\\n     * Counterpart to Solidity's `uint56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toUint56(uint256 value) internal pure returns (uint56) {\\n        if (value > type(uint56).max) {\\n            revert SafeCastOverflowedUintDowncast(56, value);\\n        }\\n        return uint56(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint48 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint48).\\n     *\\n     * Counterpart to Solidity's `uint48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toUint48(uint256 value) internal pure returns (uint48) {\\n        if (value > type(uint48).max) {\\n            revert SafeCastOverflowedUintDowncast(48, value);\\n        }\\n        return uint48(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint40 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint40).\\n     *\\n     * Counterpart to Solidity's `uint40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toUint40(uint256 value) internal pure returns (uint40) {\\n        if (value > type(uint40).max) {\\n            revert SafeCastOverflowedUintDowncast(40, value);\\n        }\\n        return uint40(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint32 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint32).\\n     *\\n     * Counterpart to Solidity's `uint32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toUint32(uint256 value) internal pure returns (uint32) {\\n        if (value > type(uint32).max) {\\n            revert SafeCastOverflowedUintDowncast(32, value);\\n        }\\n        return uint32(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint24 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint24).\\n     *\\n     * Counterpart to Solidity's `uint24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toUint24(uint256 value) internal pure returns (uint24) {\\n        if (value > type(uint24).max) {\\n            revert SafeCastOverflowedUintDowncast(24, value);\\n        }\\n        return uint24(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint16 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint16).\\n     *\\n     * Counterpart to Solidity's `uint16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toUint16(uint256 value) internal pure returns (uint16) {\\n        if (value > type(uint16).max) {\\n            revert SafeCastOverflowedUintDowncast(16, value);\\n        }\\n        return uint16(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted uint8 from uint256, reverting on\\n     * overflow (when the input is greater than largest uint8).\\n     *\\n     * Counterpart to Solidity's `uint8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toUint8(uint256 value) internal pure returns (uint8) {\\n        if (value > type(uint8).max) {\\n            revert SafeCastOverflowedUintDowncast(8, value);\\n        }\\n        return uint8(value);\\n    }\\n\\n    /**\\n     * @dev Converts a signed int256 into an unsigned uint256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be greater than or equal to 0.\\n     */\\n    function toUint256(int256 value) internal pure returns (uint256) {\\n        if (value < 0) {\\n            revert SafeCastOverflowedIntToUint(value);\\n        }\\n        return uint256(value);\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int248 from int256, reverting on\\n     * overflow (when the input is less than smallest int248 or\\n     * greater than largest int248).\\n     *\\n     * Counterpart to Solidity's `int248` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 248 bits\\n     */\\n    function toInt248(int256 value) internal pure returns (int248 downcasted) {\\n        downcasted = int248(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(248, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int240 from int256, reverting on\\n     * overflow (when the input is less than smallest int240 or\\n     * greater than largest int240).\\n     *\\n     * Counterpart to Solidity's `int240` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 240 bits\\n     */\\n    function toInt240(int256 value) internal pure returns (int240 downcasted) {\\n        downcasted = int240(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(240, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int232 from int256, reverting on\\n     * overflow (when the input is less than smallest int232 or\\n     * greater than largest int232).\\n     *\\n     * Counterpart to Solidity's `int232` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 232 bits\\n     */\\n    function toInt232(int256 value) internal pure returns (int232 downcasted) {\\n        downcasted = int232(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(232, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int224 from int256, reverting on\\n     * overflow (when the input is less than smallest int224 or\\n     * greater than largest int224).\\n     *\\n     * Counterpart to Solidity's `int224` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 224 bits\\n     */\\n    function toInt224(int256 value) internal pure returns (int224 downcasted) {\\n        downcasted = int224(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(224, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int216 from int256, reverting on\\n     * overflow (when the input is less than smallest int216 or\\n     * greater than largest int216).\\n     *\\n     * Counterpart to Solidity's `int216` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 216 bits\\n     */\\n    function toInt216(int256 value) internal pure returns (int216 downcasted) {\\n        downcasted = int216(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(216, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int208 from int256, reverting on\\n     * overflow (when the input is less than smallest int208 or\\n     * greater than largest int208).\\n     *\\n     * Counterpart to Solidity's `int208` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 208 bits\\n     */\\n    function toInt208(int256 value) internal pure returns (int208 downcasted) {\\n        downcasted = int208(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(208, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int200 from int256, reverting on\\n     * overflow (when the input is less than smallest int200 or\\n     * greater than largest int200).\\n     *\\n     * Counterpart to Solidity's `int200` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 200 bits\\n     */\\n    function toInt200(int256 value) internal pure returns (int200 downcasted) {\\n        downcasted = int200(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(200, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int192 from int256, reverting on\\n     * overflow (when the input is less than smallest int192 or\\n     * greater than largest int192).\\n     *\\n     * Counterpart to Solidity's `int192` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 192 bits\\n     */\\n    function toInt192(int256 value) internal pure returns (int192 downcasted) {\\n        downcasted = int192(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(192, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int184 from int256, reverting on\\n     * overflow (when the input is less than smallest int184 or\\n     * greater than largest int184).\\n     *\\n     * Counterpart to Solidity's `int184` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 184 bits\\n     */\\n    function toInt184(int256 value) internal pure returns (int184 downcasted) {\\n        downcasted = int184(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(184, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int176 from int256, reverting on\\n     * overflow (when the input is less than smallest int176 or\\n     * greater than largest int176).\\n     *\\n     * Counterpart to Solidity's `int176` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 176 bits\\n     */\\n    function toInt176(int256 value) internal pure returns (int176 downcasted) {\\n        downcasted = int176(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(176, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int168 from int256, reverting on\\n     * overflow (when the input is less than smallest int168 or\\n     * greater than largest int168).\\n     *\\n     * Counterpart to Solidity's `int168` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 168 bits\\n     */\\n    function toInt168(int256 value) internal pure returns (int168 downcasted) {\\n        downcasted = int168(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(168, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int160 from int256, reverting on\\n     * overflow (when the input is less than smallest int160 or\\n     * greater than largest int160).\\n     *\\n     * Counterpart to Solidity's `int160` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 160 bits\\n     */\\n    function toInt160(int256 value) internal pure returns (int160 downcasted) {\\n        downcasted = int160(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(160, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int152 from int256, reverting on\\n     * overflow (when the input is less than smallest int152 or\\n     * greater than largest int152).\\n     *\\n     * Counterpart to Solidity's `int152` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 152 bits\\n     */\\n    function toInt152(int256 value) internal pure returns (int152 downcasted) {\\n        downcasted = int152(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(152, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int144 from int256, reverting on\\n     * overflow (when the input is less than smallest int144 or\\n     * greater than largest int144).\\n     *\\n     * Counterpart to Solidity's `int144` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 144 bits\\n     */\\n    function toInt144(int256 value) internal pure returns (int144 downcasted) {\\n        downcasted = int144(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(144, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int136 from int256, reverting on\\n     * overflow (when the input is less than smallest int136 or\\n     * greater than largest int136).\\n     *\\n     * Counterpart to Solidity's `int136` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 136 bits\\n     */\\n    function toInt136(int256 value) internal pure returns (int136 downcasted) {\\n        downcasted = int136(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(136, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int128 from int256, reverting on\\n     * overflow (when the input is less than smallest int128 or\\n     * greater than largest int128).\\n     *\\n     * Counterpart to Solidity's `int128` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 128 bits\\n     */\\n    function toInt128(int256 value) internal pure returns (int128 downcasted) {\\n        downcasted = int128(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(128, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int120 from int256, reverting on\\n     * overflow (when the input is less than smallest int120 or\\n     * greater than largest int120).\\n     *\\n     * Counterpart to Solidity's `int120` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 120 bits\\n     */\\n    function toInt120(int256 value) internal pure returns (int120 downcasted) {\\n        downcasted = int120(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(120, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int112 from int256, reverting on\\n     * overflow (when the input is less than smallest int112 or\\n     * greater than largest int112).\\n     *\\n     * Counterpart to Solidity's `int112` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 112 bits\\n     */\\n    function toInt112(int256 value) internal pure returns (int112 downcasted) {\\n        downcasted = int112(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(112, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int104 from int256, reverting on\\n     * overflow (when the input is less than smallest int104 or\\n     * greater than largest int104).\\n     *\\n     * Counterpart to Solidity's `int104` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 104 bits\\n     */\\n    function toInt104(int256 value) internal pure returns (int104 downcasted) {\\n        downcasted = int104(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(104, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int96 from int256, reverting on\\n     * overflow (when the input is less than smallest int96 or\\n     * greater than largest int96).\\n     *\\n     * Counterpart to Solidity's `int96` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 96 bits\\n     */\\n    function toInt96(int256 value) internal pure returns (int96 downcasted) {\\n        downcasted = int96(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(96, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int88 from int256, reverting on\\n     * overflow (when the input is less than smallest int88 or\\n     * greater than largest int88).\\n     *\\n     * Counterpart to Solidity's `int88` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 88 bits\\n     */\\n    function toInt88(int256 value) internal pure returns (int88 downcasted) {\\n        downcasted = int88(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(88, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int80 from int256, reverting on\\n     * overflow (when the input is less than smallest int80 or\\n     * greater than largest int80).\\n     *\\n     * Counterpart to Solidity's `int80` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 80 bits\\n     */\\n    function toInt80(int256 value) internal pure returns (int80 downcasted) {\\n        downcasted = int80(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(80, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int72 from int256, reverting on\\n     * overflow (when the input is less than smallest int72 or\\n     * greater than largest int72).\\n     *\\n     * Counterpart to Solidity's `int72` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 72 bits\\n     */\\n    function toInt72(int256 value) internal pure returns (int72 downcasted) {\\n        downcasted = int72(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(72, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int64 from int256, reverting on\\n     * overflow (when the input is less than smallest int64 or\\n     * greater than largest int64).\\n     *\\n     * Counterpart to Solidity's `int64` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 64 bits\\n     */\\n    function toInt64(int256 value) internal pure returns (int64 downcasted) {\\n        downcasted = int64(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(64, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int56 from int256, reverting on\\n     * overflow (when the input is less than smallest int56 or\\n     * greater than largest int56).\\n     *\\n     * Counterpart to Solidity's `int56` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 56 bits\\n     */\\n    function toInt56(int256 value) internal pure returns (int56 downcasted) {\\n        downcasted = int56(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(56, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int48 from int256, reverting on\\n     * overflow (when the input is less than smallest int48 or\\n     * greater than largest int48).\\n     *\\n     * Counterpart to Solidity's `int48` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 48 bits\\n     */\\n    function toInt48(int256 value) internal pure returns (int48 downcasted) {\\n        downcasted = int48(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(48, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int40 from int256, reverting on\\n     * overflow (when the input is less than smallest int40 or\\n     * greater than largest int40).\\n     *\\n     * Counterpart to Solidity's `int40` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 40 bits\\n     */\\n    function toInt40(int256 value) internal pure returns (int40 downcasted) {\\n        downcasted = int40(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(40, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int32 from int256, reverting on\\n     * overflow (when the input is less than smallest int32 or\\n     * greater than largest int32).\\n     *\\n     * Counterpart to Solidity's `int32` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 32 bits\\n     */\\n    function toInt32(int256 value) internal pure returns (int32 downcasted) {\\n        downcasted = int32(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(32, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int24 from int256, reverting on\\n     * overflow (when the input is less than smallest int24 or\\n     * greater than largest int24).\\n     *\\n     * Counterpart to Solidity's `int24` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 24 bits\\n     */\\n    function toInt24(int256 value) internal pure returns (int24 downcasted) {\\n        downcasted = int24(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(24, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int16 from int256, reverting on\\n     * overflow (when the input is less than smallest int16 or\\n     * greater than largest int16).\\n     *\\n     * Counterpart to Solidity's `int16` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 16 bits\\n     */\\n    function toInt16(int256 value) internal pure returns (int16 downcasted) {\\n        downcasted = int16(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(16, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the downcasted int8 from int256, reverting on\\n     * overflow (when the input is less than smallest int8 or\\n     * greater than largest int8).\\n     *\\n     * Counterpart to Solidity's `int8` operator.\\n     *\\n     * Requirements:\\n     *\\n     * - input must fit into 8 bits\\n     */\\n    function toInt8(int256 value) internal pure returns (int8 downcasted) {\\n        downcasted = int8(value);\\n        if (downcasted != value) {\\n            revert SafeCastOverflowedIntDowncast(8, value);\\n        }\\n    }\\n\\n    /**\\n     * @dev Converts an unsigned uint256 into a signed int256.\\n     *\\n     * Requirements:\\n     *\\n     * - input must be less than or equal to maxInt256.\\n     */\\n    function toInt256(uint256 value) internal pure returns (int256) {\\n        // Note: Unsafe cast below is okay because `type(int256).max` is guaranteed to be positive\\n        if (value > uint256(type(int256).max)) {\\n            revert SafeCastOverflowedUintToInt(value);\\n        }\\n        return int256(value);\\n    }\\n\\n    /**\\n     * @dev Cast a boolean (false or true) to a uint256 (0 or 1) with no jump.\\n     */\\n    function toUint(bool b) internal pure returns (uint256 u) {\\n        assembly (\\\"memory-safe\\\") {\\n            u := iszero(iszero(b))\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\"},\"@openzeppelin/contracts/utils/math/SignedMath.sol\":{\"content\":\"// SPDX-License-Identifier: MIT\\n// OpenZeppelin Contracts (last updated v5.1.0) (utils/math/SignedMath.sol)\\n\\npragma solidity ^0.8.20;\\n\\nimport {SafeCast} from \\\"./SafeCast.sol\\\";\\n\\n/**\\n * @dev Standard signed math utilities missing in the Solidity language.\\n */\\nlibrary SignedMath {\\n    /**\\n     * @dev Branchless ternary evaluation for `a ? b : c`. Gas costs are constant.\\n     *\\n     * IMPORTANT: This function may reduce bytecode size and consume less gas when used standalone.\\n     * However, the compiler may optimize Solidity ternary operations (i.e. `a ? b : c`) to only compute\\n     * one branch when needed, making this function more expensive.\\n     */\\n    function ternary(bool condition, int256 a, int256 b) internal pure returns (int256) {\\n        unchecked {\\n            // branchless ternary works because:\\n            // b ^ (a ^ b) == a\\n            // b ^ 0 == b\\n            return b ^ ((a ^ b) * int256(SafeCast.toUint(condition)));\\n        }\\n    }\\n\\n    /**\\n     * @dev Returns the largest of two signed numbers.\\n     */\\n    function max(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a > b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the smallest of two signed numbers.\\n     */\\n    function min(int256 a, int256 b) internal pure returns (int256) {\\n        return ternary(a < b, a, b);\\n    }\\n\\n    /**\\n     * @dev Returns the average of two signed numbers without overflow.\\n     * The result is rounded towards zero.\\n     */\\n    function average(int256 a, int256 b) internal pure returns (int256) {\\n        // Formula from the book \\\"Hacker's Delight\\\"\\n        int256 x = (a & b) + ((a ^ b) >> 1);\\n        return x + (int256(uint256(x) >> 255) & (a ^ b));\\n    }\\n\\n    /**\\n     * @dev Returns the absolute unsigned value of a signed value.\\n     */\\n    function abs(int256 n) internal pure returns (uint256) {\\n        unchecked {\\n            // Formula from the \\\"Bit Twiddling Hacks\\\" by Sean Eron Anderson.\\n            // Since `n` is a signed integer, the generated bytecode will use the SAR opcode to perform the right shift,\\n            // taking advantage of the most significant (or \\\"sign\\\" bit) in two's complement representation.\\n            // This opcode adds new most significant bits set to the value of the previous most significant bit. As a result,\\n            // the mask will either be `bytes32(0)` (if n is positive) or `~bytes32(0)` (if n is negative).\\n            int256 mask = n >> 255;\\n\\n            // A `bytes32(0)` mask leaves the input unchanged, while a `~bytes32(0)` mask complements it.\\n            return uint256((n + mask) ^ mask);\\n        }\\n    }\\n}\\n\",\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\"},\"contracts/GM/MarketToken_OFT.sol\":{\"content\":\"// SPDX-License-Identifier: UNLICENSED\\npragma solidity ^0.8.22;\\n\\nimport { Ownable } from \\\"@openzeppelin/contracts/access/Ownable.sol\\\";\\nimport { ERC20Permit } from \\\"@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol\\\";\\n\\nimport { OFT } from \\\"@layerzerolabs/oft-evm/contracts/OFT.sol\\\";\\n\\ncontract MarketToken_OFT is OFT, ERC20Permit {\\n    /// @dev Using msg.sender instead of _delegate in Ownable to avoid via-ir\\n    constructor(\\n        string memory _name,\\n        string memory _symbol,\\n        address _lzEndpoint,\\n        address _delegate\\n    ) OFT(_name, _symbol, _lzEndpoint, _delegate) ERC20Permit(_name) Ownable(msg.sender) {}\\n}\\n\",\"keccak256\":\"0xcc4ebd0ae1addcc6fa2633a5c45531a45871ad87643ab062365bad13f2c21daf\",\"license\":\"UNLICENSED\"}},\"version\":1}",
+  "bytecode": "0x6101a06040523480156200001257600080fd5b506040516200414c3803806200414c833981016040819052620000359162000439565b8380604051806040016040528060018152602001603160f81b815250868686868383620000676200027960201b60201c565b84848181818133806200009557604051631e4fbdf760e01b8152600060048201526024015b60405180910390fd5b620000a0816200027e565b506001600160a01b038083166080528116620000cf57604051632d618d8160e21b815260040160405180910390fd5b60805160405163ca5eb5e160e01b81526001600160a01b0383811660048301529091169063ca5eb5e190602401600060405180830381600087803b1580156200011757600080fd5b505af11580156200012c573d6000803e3d6000fd5b505050505050505062000144620002ce60201b60201c565b60ff168360ff1610156200016b576040516301e9714b60e41b815260040160405180910390fd5b62000178600684620004de565b6200018590600a620005f7565b60a05250600891506200019b90508382620006a0565b506009620001aa8282620006a0565b50620001c29550879450600a935050620002d3915050565b61016052620001d381600b620002d3565b61018052815160208084019190912061012052815190820120610140524660e052620002636101205161014051604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201529081019290925260608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b60c0525050306101005250620007c69350505050565b601290565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b600690565b6000602083511015620002f357620002eb836200030c565b905062000306565b81620003008482620006a0565b5060ff90505b92915050565b600080829050601f815111156200033a578260405163305a27a960e01b81526004016200008c91906200076c565b80516200034782620007a1565b179392505050565b634e487b7160e01b600052604160045260246000fd5b60005b838110156200038257818101518382015260200162000368565b50506000910152565b600082601f8301126200039d57600080fd5b81516001600160401b0380821115620003ba57620003ba6200034f565b604051601f8301601f19908116603f01168101908282118183101715620003e557620003e56200034f565b81604052838152866020858801011115620003ff57600080fd5b6200041284602083016020890162000365565b9695505050505050565b80516001600160a01b03811681146200043457600080fd5b919050565b600080600080608085870312156200045057600080fd5b84516001600160401b03808211156200046857600080fd5b62000476888389016200038b565b955060208701519150808211156200048d57600080fd5b506200049c878288016200038b565b935050620004ad604086016200041c565b9150620004bd606086016200041c565b905092959194509250565b634e487b7160e01b600052601160045260246000fd5b60ff8281168282160390811115620003065762000306620004c8565b600181815b808511156200053b5781600019048211156200051f576200051f620004c8565b808516156200052d57918102915b93841c9390800290620004ff565b509250929050565b600082620005545750600162000306565b81620005635750600062000306565b81600181146200057c57600281146200058757620005a7565b600191505062000306565b60ff8411156200059b576200059b620004c8565b50506001821b62000306565b5060208310610133831016604e8410600b8410161715620005cc575081810a62000306565b620005d88383620004fa565b8060001904821115620005ef57620005ef620004c8565b029392505050565b60006200060860ff84168362000543565b9392505050565b600181811c908216806200062457607f821691505b6020821081036200064557634e487b7160e01b600052602260045260246000fd5b50919050565b601f8211156200069b576000816000526020600020601f850160051c81016020861015620006765750805b601f850160051c820191505b81811015620006975782815560010162000682565b5050505b505050565b81516001600160401b03811115620006bc57620006bc6200034f565b620006d481620006cd84546200060f565b846200064b565b602080601f8311600181146200070c5760008415620006f35750858301515b600019600386901b1c1916600185901b17855562000697565b600085815260208120601f198616915b828110156200073d578886015182559484019460019091019084016200071c565b50858210156200075c5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b60208152600082518060208401526200078d81604085016020870162000365565b601f01601f19169190910160400192915050565b80516020808301519190811015620006455760001960209190910360031b1b16919050565b60805160a05160c05160e05161010051610120516101405161016051610180516138cf6200087d6000396000611b4f01526000611b22015260006118760152600061184e015260006117a9015260006117d3015260006117fd0152600081816106a701528181611ed701528181611f4c015261215001526000818161051e01528181610af6015281816111b90152818161156a01528181611a00015281816122f30152818161262a01526126e301526138cf6000f3fe60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "deployedBytecode": "0x60806040526004361061027d5760003560e01c80637ecebe001161014f578063bb0b6a53116100c1578063d42438851161007a578063d4243885146107f1578063d505accf14610811578063dd62ed3e14610831578063f2fde38b14610877578063fc0c546a146104a2578063ff7bd03d1461089757600080fd5b8063bb0b6a531461073d578063bc70b3541461076a578063bd815db01461078a578063c7c7f5b31461079d578063ca5eb5e1146107be578063d045a0dc146107de57600080fd5b806395d89b411161011357806395d89b4114610680578063963efcaa146106955780639f68b964146106c9578063a9059cbb146106dd578063b731ea0a146106fd578063b98bd0701461071d57600080fd5b80637ecebe00146105e657806382413eac1461060657806384b0196e14610626578063857749b01461064e5780638da5cb5b1461066257600080fd5b8063313ce567116101f35780635a0dfe4d116101ac5780635a0dfe4d146104d55780635e280f111461050c5780636fc1b31e1461054057806370a0823114610560578063715018a6146105965780637d25a05e146105ab57600080fd5b8063313ce5671461041e5780633400288b146104405780633644e515146104605780633b6f743b1461047557806352ae2879146104a25780635535d461146104b557600080fd5b8063134d4f2511610245578063134d4f2514610359578063156a0d0f1461038157806317442b70146103a857806318160ddd146103ca5780631f5e1334146103e957806323b872dd146103fe57600080fd5b806306fdde0314610282578063095ea7b3146102ad5780630d35b415146102dd578063111ecdad1461030c57806313137d6514610344575b600080fd5b34801561028e57600080fd5b506102976108b7565b6040516102a4919061288d565b60405180910390f35b3480156102b957600080fd5b506102cd6102c83660046128b5565b610949565b60405190151581526020016102a4565b3480156102e957600080fd5b506102fd6102f83660046128f9565b610963565b6040516102a49392919061292d565b34801561031857600080fd5b5060045461032c906001600160a01b031681565b6040516001600160a01b0390911681526020016102a4565b610357610352366004612a20565b610af4565b005b34801561036557600080fd5b5061036e600281565b60405161ffff90911681526020016102a4565b34801561038d57600080fd5b506040805162b9270b60e21b815260016020820152016102a4565b3480156103b457600080fd5b50604080516001815260026020820152016102a4565b3480156103d657600080fd5b506007545b6040519081526020016102a4565b3480156103f557600080fd5b5061036e600181565b34801561040a57600080fd5b506102cd610419366004612abf565b610bb4565b34801561042a57600080fd5b5060125b60405160ff90911681526020016102a4565b34801561044c57600080fd5b5061035761045b366004612b19565b610bda565b34801561046c57600080fd5b506103db610bf0565b34801561048157600080fd5b50610495610490366004612b43565b610bff565b6040516102a49190612b94565b3480156104ae57600080fd5b503061032c565b3480156104c157600080fd5b506102976104d0366004612bbd565b610c66565b3480156104e157600080fd5b506102cd6104f0366004612b19565b63ffffffff919091166000908152600160205260409020541490565b34801561051857600080fd5b5061032c7f000000000000000000000000000000000000000000000000000000000000000081565b34801561054c57600080fd5b5061035761055b366004612bf0565b610d0b565b34801561056c57600080fd5b506103db61057b366004612bf0565b6001600160a01b031660009081526005602052604090205490565b3480156105a257600080fd5b50610357610d68565b3480156105b757600080fd5b506105ce6105c6366004612b19565b600092915050565b6040516001600160401b0390911681526020016102a4565b3480156105f257600080fd5b506103db610601366004612bf0565b610d7c565b34801561061257600080fd5b506102cd610621366004612c0d565b610d9a565b34801561063257600080fd5b5061063b610daf565b6040516102a49796959493929190612c73565b34801561065a57600080fd5b50600661042e565b34801561066e57600080fd5b506000546001600160a01b031661032c565b34801561068c57600080fd5b50610297610df5565b3480156106a157600080fd5b506103db7f000000000000000000000000000000000000000000000000000000000000000081565b3480156106d557600080fd5b5060006102cd565b3480156106e957600080fd5b506102cd6106f83660046128b5565b610e04565b34801561070957600080fd5b5060025461032c906001600160a01b031681565b34801561072957600080fd5b50610357610738366004612d50565b610e12565b34801561074957600080fd5b506103db610758366004612d91565b60016020526000908152604090205481565b34801561077657600080fd5b50610297610785366004612dac565b610e2c565b610357610798366004612d50565b610fd4565b6107b06107ab366004612e0c565b61115e565b6040516102a4929190612e79565b3480156107ca57600080fd5b506103576107d9366004612bf0565b611192565b6103576107ec366004612a20565b611218565b3480156107fd57600080fd5b5061035761080c366004612bf0565b611247565b34801561081d57600080fd5b5061035761082c366004612ecb565b61129d565b34801561083d57600080fd5b506103db61084c366004612f42565b6001600160a01b03918216600090815260066020908152604080832093909416825291909152205490565b34801561088357600080fd5b50610357610892366004612bf0565b6113d7565b3480156108a357600080fd5b506102cd6108b2366004612f70565b611415565b6060600880546108c690612f8c565b80601f01602080910402602001604051908101604052809291908181526020018280546108f290612f8c565b801561093f5780601f106109145761010080835404028352916020019161093f565b820191906000526020600020905b81548152906001019060200180831161092257829003601f168201915b5050505050905090565b60003361095781858561144b565b60019150505b92915050565b60408051808201909152600080825260208201526060610996604051806040016040528060008152602001600081525090565b600080306001600160a01b031663fc0c546a6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156109d7573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906109fb9190612fc0565b6001600160a01b03166318160ddd6040518163ffffffff1660e01b8152600401602060405180830381865afa158015610a38573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a5c9190612fdd565b60408051808201825284815260208082018490528251600080825291810190935290975091925090610ab1565b604080518082019091526000815260606020820152815260200190600190039081610a895790505b509350600080610ad6604089013560608a0135610ad160208c018c612d91565b61145d565b60408051808201909152918252602082015296989597505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163314610b44576040516391ac5e4f60e01b81523360048201526024015b60405180910390fd5b60208701803590610b5e90610b59908a612d91565b611499565b14610b9c57610b706020880188612d91565b60405163309afaf360e21b815263ffffffff909116600482015260208801356024820152604401610b3b565b610bab878787878787876114d5565b50505050505050565b600033610bc285828561163c565b610bcd8585856116bb565b60019150505b9392505050565b610be261171a565b610bec8282611747565b5050565b6000610bfa61179c565b905090565b60408051808201909152600080825260208201526000610c2f60408501356060860135610ad16020880188612d91565b915050600080610c3f86846118c7565b9092509050610c5c610c546020880188612d91565b8383886119ea565b9695505050505050565b600360209081526000928352604080842090915290825290208054610c8a90612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610cb690612f8c565b8015610d035780601f10610cd857610100808354040283529160200191610d03565b820191906000526020600020905b815481529060010190602001808311610ce657829003601f168201915b505050505081565b610d1361171a565b600480546001600160a01b0319166001600160a01b0383169081179091556040519081527ff0be4f1e87349231d80c36b33f9e8639658eeaf474014dee15a3e6a4d4414197906020015b60405180910390a150565b610d7061171a565b610d7a6000611acb565b565b6001600160a01b0381166000908152600c602052604081205461095d565b6001600160a01b03811630145b949350505050565b600060608060008060006060610dc3611b1b565b610dcb611b48565b60408051600080825260208201909252600f60f81b9b939a50919850469750309650945092509050565b6060600980546108c690612f8c565b6000336109578185856116bb565b610e1a61171a565b610bec610e2782846130ad565b611b75565b63ffffffff8416600090815260036020908152604080832061ffff87168452909152812080546060929190610e6090612f8c565b80601f0160208091040260200160405190810160405280929190818152602001828054610e8c90612f8c565b8015610ed95780601f10610eae57610100808354040283529160200191610ed9565b820191906000526020600020905b815481529060010190602001808311610ebc57829003601f168201915b505050505090508051600003610f295783838080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929450610da79350505050565b6000839003610f39579050610da7565b60028310610fb757610f8084848080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250611c7c92505050565b80610f8e84600281886131c2565b604051602001610fa0939291906131ec565b604051602081830303815290604052915050610da7565b8383604051639a6d49cd60e01b8152600401610b3b92919061323d565b60005b818110156110dd5736838383818110610ff257610ff2613251565b90506020028101906110049190613267565b90506110376110166020830183612d91565b602083013563ffffffff919091166000908152600160205260409020541490565b61104157506110d5565b3063d045a0dc60c08301358360a0810135611060610100830183613288565b611071610100890160e08a01612bf0565b61107f6101208a018a613288565b6040518963ffffffff1660e01b81526004016110a197969594939291906132e3565b6000604051808303818588803b1580156110ba57600080fd5b505af11580156110ce573d6000803e3d6000fd5b5050505050505b600101610fd7565b50336001600160a01b0316638e9e70996040518163ffffffff1660e01b8152600401600060405180830381865afa15801561111c573d6000803e3d6000fd5b505050506040513d6000823e601f3d908101601f191682016040526111449190810190613369565b604051638351eea760e01b8152600401610b3b919061288d565b6111666127f6565b6040805180820190915260008082526020820152611185858585611ca8565b915091505b935093915050565b61119a61171a565b60405163ca5eb5e160e01b81526001600160a01b0382811660048301527f0000000000000000000000000000000000000000000000000000000000000000169063ca5eb5e190602401600060405180830381600087803b1580156111fd57600080fd5b505af1158015611211573d6000803e3d6000fd5b5050505050565b3330146112385760405163029a949d60e31b815260040160405180910390fd5b610bab87878787878787610b9c565b61124f61171a565b600280546001600160a01b0319166001600160a01b0383169081179091556040519081527fd48d879cef83a1c0bdda516f27b13ddb1b3f8bbac1c9e1511bb2a659c242776090602001610d5d565b834211156112c15760405163313c898160e11b815260048101859052602401610b3b565b60007f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c988888861130e8c6001600160a01b03166000908152600c6020526040902080546001810190915590565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e001604051602081830303815290604052805190602001209050600061136982611da3565b9050600061137982878787611dd0565b9050896001600160a01b0316816001600160a01b0316146113c0576040516325c0072360e11b81526001600160a01b0380831660048301528b166024820152604401610b3b565b6113cb8a8a8a61144b565b50505050505050505050565b6113df61171a565b6001600160a01b03811661140957604051631e4fbdf760e01b815260006004820152602401610b3b565b61141281611acb565b50565b600060208201803590600190839061142d9086612d91565b63ffffffff1681526020810191909152604001600020541492915050565b6114588383836001611dfe565b505050565b60008061146985611ed3565b91508190508381101561118a576040516371c4efed60e01b81526004810182905260248101859052604401610b3b565b63ffffffff81166000908152600160205260408120548061095d5760405163f6ff4fb760e01b815263ffffffff84166004820152602401610b3b565b60006114e76114e48787611f0a565b90565b90506000611513826115016114fc8a8a611f22565b611f45565b61150e60208d018d612d91565b611f7a565b905060288611156115da57600061155061153360608c0160408d016133d6565b61154060208d018d612d91565b8461154b8c8c611fa2565b611fed565b604051633e5ac80960e11b81529091506001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001690637cb59012906115a69086908d9060009087906004016133f3565b600060405180830381600087803b1580156115c057600080fd5b505af11580156115d4573d6000803e3d6000fd5b50505050505b6001600160a01b038216887fefed6d3500546b29533b128a29e3a94d70788727f0507505ac12eaf2e578fd9c61161360208d018d612d91565b6040805163ffffffff9092168252602082018690520160405180910390a3505050505050505050565b6001600160a01b038381166000908152600660209081526040808320938616835292905220546000198110156116b557818110156116a657604051637dc7a0d960e11b81526001600160a01b03841660048201526024810182905260448101839052606401610b3b565b6116b584848484036000611dfe565b50505050565b6001600160a01b0383166116e557604051634b637e8f60e11b815260006004820152602401610b3b565b6001600160a01b03821661170f5760405163ec442f0560e01b815260006004820152602401610b3b565b61145883838361201f565b6000546001600160a01b03163314610d7a5760405163118cdaa760e01b8152336004820152602401610b3b565b63ffffffff8216600081815260016020908152604091829020849055815192835282018390527f238399d427b947898edb290f5ff0f9109849b1c3ba196a42e35f00c50a54b98b910160405180910390a15050565b6000306001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161480156117f557507f000000000000000000000000000000000000000000000000000000000000000046145b1561181f57507f000000000000000000000000000000000000000000000000000000000000000090565b610bfa604080517f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f60208201527f0000000000000000000000000000000000000000000000000000000000000000918101919091527f000000000000000000000000000000000000000000000000000000000000000060608201524660808201523060a082015260009060c00160405160208183030381529060405280519060200120905090565b606080600061192485602001356118dd86612149565b6118ea60a0890189613288565b8080601f01602080910402602001604051908101604052809392919081815260200183838082843760009201919091525061217592505050565b909350905060008161193757600161193a565b60025b905061195a61194c6020880188612d91565b8261078560808a018a613288565b6004549093506001600160a01b031680156119e05760405163043a78eb60e01b81526001600160a01b0382169063043a78eb9061199d9088908890600401613424565b602060405180830381865afa1580156119ba573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906119de9190613449565b505b5050509250929050565b60408051808201909152600080825260208201527f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663ddc28c586040518060a001604052808863ffffffff168152602001611a4d89611499565b8152602001878152602001868152602001851515815250306040518363ffffffff1660e01b8152600401611a82929190613466565b6040805180830381865afa158015611a9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611ac2919061350f565b95945050505050565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600a6121ef565b6060610bfa7f0000000000000000000000000000000000000000000000000000000000000000600b6121ef565b60005b8151811015611c4c57611ba7828281518110611b9657611b96613251565b602002602001015160400151611c7c565b818181518110611bb957611bb9613251565b60200260200101516040015160036000848481518110611bdb57611bdb613251565b60200260200101516000015163ffffffff1663ffffffff1681526020019081526020016000206000848481518110611c1557611c15613251565b60200260200101516020015161ffff1661ffff1681526020019081526020016000209081611c43919061357b565b50600101611b78565b507fbe4864a8e820971c0247f5992e2da559595f7bf076a21cb5928d443d2a13b67481604051610d5d919061363a565b600281015161ffff8116600314610bec5781604051639a6d49cd60e01b8152600401610b3b919061288d565b611cb06127f6565b6040805180820190915260008082526020820152600080611ce733604089013560608a0135611ce260208c018c612d91565b61229a565b91509150600080611cf889846118c7565b9092509050611d24611d0d60208b018b612d91565b8383611d1e368d90038d018d6136c5565b8b6122c0565b60408051808201909152858152602080820186905282519298509096503391907f85496b760a4b7f8d66384b9df21b381f5d1b1e79f229a47aaf4c232edc2fe59a90611d72908d018d612d91565b6040805163ffffffff909216825260208201899052810187905260600160405180910390a350505050935093915050565b600061095d611db061179c565b8360405161190160f01b8152600281019290925260228201526042902090565b600080600080611de2888888886123cb565b925092509250611df2828261249a565b50909695505050505050565b6001600160a01b038416611e285760405163e602df0560e01b815260006004820152602401610b3b565b6001600160a01b038316611e5257604051634a1406b160e11b815260006004820152602401610b3b565b6001600160a01b03808516600090815260066020908152604080832093871683529290522082905580156116b557826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92584604051611ec591815260200190565b60405180910390a350505050565b60007f0000000000000000000000000000000000000000000000000000000000000000611f00818461370d565b61095d919061372f565b6000611f1960208284866131c2565b610bd391613746565b6000611f326028602084866131c2565b611f3b91613764565b60c01c9392505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000006001600160401b03841661372f565b60006001600160a01b038416611f905761dead93505b611f9a8484612553565b509092915050565b6060611fb182602881866131c2565b8080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929695505050505050565b6060848484846040516020016120069493929190613794565b6040516020818303038152906040529050949350505050565b6001600160a01b03831661204a57806007600082825461203f91906137e3565b909155506120bc9050565b6001600160a01b0383166000908152600560205260409020548181101561209d5760405163391434e360e21b81526001600160a01b03851660048201526024810182905260448101839052606401610b3b565b6001600160a01b03841660009081526005602052604090209082900390555b6001600160a01b0382166120d8576007805482900390556120f7565b6001600160a01b03821660009081526005602052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161213c91815260200190565b60405180910390a3505050565b600061095d7f00000000000000000000000000000000000000000000000000000000000000008361370d565b80516060901515806121be5784846040516020016121aa92919091825260c01b6001600160c01b031916602082015260280190565b6040516020818303038152906040526121e5565b848433856040516020016121d594939291906137f6565b6040516020818303038152906040525b9150935093915050565b606060ff83146122095761220283612589565b905061095d565b81805461221590612f8c565b80601f016020809104026020016040519081016040528092919081815260200182805461224190612f8c565b801561228e5780601f106122635761010080835404028352916020019161228e565b820191906000526020600020905b81548152906001019060200180831161227157829003601f168201915b5050505050905061095d565b6000806122a885858561145d565b90925090506122b786836125c8565b94509492505050565b6122c86127f6565b60006122d784600001516125fe565b6020850151909150156122f1576122f18460200151612626565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632637a450826040518060a001604052808b63ffffffff1681526020016123418c611499565b81526020018a815260200189815260200160008960200151111515815250866040518463ffffffff1660e01b815260040161237d929190613466565b60806040518083038185885af115801561239b573d6000803e3d6000fd5b50505050506040513d601f19601f820116820180604052508101906123c09190613839565b979650505050505050565b600080807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156124065750600091506003905082612490565b604080516000808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561245a573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b03811661248657506000925060019150829050612490565b9250600091508190505b9450945094915050565b60008260038111156124ae576124ae613883565b036124b7575050565b60018260038111156124cb576124cb613883565b036124e95760405163f645eedf60e01b815260040160405180910390fd5b60028260038111156124fd576124fd613883565b0361251e5760405163fce698f760e01b815260048101829052602401610b3b565b600382600381111561253257612532613883565b03610bec576040516335e2f38360e21b815260048101829052602401610b3b565b6001600160a01b03821661257d5760405163ec442f0560e01b815260006004820152602401610b3b565b610bec6000838361201f565b6060600061259683612708565b604080516020808252818301909252919250600091906020820181803683375050509182525060208101929092525090565b6001600160a01b0382166125f257604051634b637e8f60e11b815260006004820152602401610b3b565b610bec8260008361201f565b6000813414612622576040516304fb820960e51b8152346004820152602401610b3b565b5090565b60007f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663e4fe1d946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612686573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906126aa9190612fc0565b90506001600160a01b0381166126d3576040516329b99a9560e11b815260040160405180910390fd5b610bec6001600160a01b038216337f000000000000000000000000000000000000000000000000000000000000000085612730565b600060ff8216601f81111561095d57604051632cd44ac360e21b815260040160405180910390fd5b604080516001600160a01b038581166024830152841660448201526064808201849052825180830390910181526084909101909152602080820180516001600160e01b03166323b872dd60e01b17815282516116b5938893909260009283929183919082885af1806127a8576040513d6000823e3d81fd5b50506000513d915081156127c05780600114156127cd565b6001600160a01b0384163b155b156116b557604051635274afe760e01b81526001600160a01b0385166004820152602401610b3b565b60405180606001604052806000801916815260200160006001600160401b03168152602001612838604051806040016040528060008152602001600081525090565b905290565b60005b83811015612858578181015183820152602001612840565b50506000910152565b6000815180845261287981602086016020860161283d565b601f01601f19169290920160200192915050565b602081526000610bd36020830184612861565b6001600160a01b038116811461141257600080fd5b600080604083850312156128c857600080fd5b82356128d3816128a0565b946020939093013593505050565b600060e082840312156128f357600080fd5b50919050565b60006020828403121561290b57600080fd5b81356001600160401b0381111561292157600080fd5b610da7848285016128e1565b8351815260208085015190820152600060a08201604060a0604085015281865180845260c08601915060c08160051b8701019350602080890160005b838110156129a85788870360bf1901855281518051885283015183880187905261299587890182612861565b9750509382019390820190600101612969565b50508751606088015250505060208501516080850152509050610da7565b6000606082840312156128f357600080fd5b60008083601f8401126129ea57600080fd5b5081356001600160401b03811115612a0157600080fd5b602083019150836020828501011115612a1957600080fd5b9250929050565b600080600080600080600060e0888a031215612a3b57600080fd5b612a4589896129c6565b96506060880135955060808801356001600160401b0380821115612a6857600080fd5b612a748b838c016129d8565b909750955060a08a01359150612a89826128a0565b90935060c08901359080821115612a9f57600080fd5b50612aac8a828b016129d8565b989b979a50959850939692959293505050565b600080600060608486031215612ad457600080fd5b8335612adf816128a0565b92506020840135612aef816128a0565b929592945050506040919091013590565b803563ffffffff81168114612b1457600080fd5b919050565b60008060408385031215612b2c57600080fd5b6128d383612b00565b801515811461141257600080fd5b60008060408385031215612b5657600080fd5b82356001600160401b03811115612b6c57600080fd5b612b78858286016128e1565b9250506020830135612b8981612b35565b809150509250929050565b81518152602080830151908201526040810161095d565b803561ffff81168114612b1457600080fd5b60008060408385031215612bd057600080fd5b612bd983612b00565b9150612be760208401612bab565b90509250929050565b600060208284031215612c0257600080fd5b8135610bd3816128a0565b60008060008060a08587031215612c2357600080fd5b612c2d86866129c6565b935060608501356001600160401b03811115612c4857600080fd5b612c54878288016129d8565b9094509250506080850135612c68816128a0565b939692955090935050565b60ff60f81b881681526000602060e06020840152612c9460e084018a612861565b8381036040850152612ca6818a612861565b606085018990526001600160a01b038816608086015260a0850187905284810360c08601528551808252602080880193509091019060005b81811015612cfa57835183529284019291840191600101612cde565b50909c9b505050505050505050505050565b60008083601f840112612d1e57600080fd5b5081356001600160401b03811115612d3557600080fd5b6020830191508360208260051b8501011115612a1957600080fd5b60008060208385031215612d6357600080fd5b82356001600160401b03811115612d7957600080fd5b612d8585828601612d0c565b90969095509350505050565b600060208284031215612da357600080fd5b610bd382612b00565b60008060008060608587031215612dc257600080fd5b612dcb85612b00565b9350612dd960208601612bab565b925060408501356001600160401b03811115612df457600080fd5b612e00878288016129d8565b95989497509550505050565b60008060008385036080811215612e2257600080fd5b84356001600160401b03811115612e3857600080fd5b612e44878288016128e1565b9450506040601f1982011215612e5957600080fd5b506020840191506060840135612e6e816128a0565b809150509250925092565b600060c082019050835182526001600160401b0360208501511660208301526040840151612eb4604084018280518252602090810151910152565b5082516080830152602083015160a0830152610bd3565b600080600080600080600060e0888a031215612ee657600080fd5b8735612ef1816128a0565b96506020880135612f01816128a0565b95506040880135945060608801359350608088013560ff81168114612f2557600080fd5b9699959850939692959460a0840135945060c09093013592915050565b60008060408385031215612f5557600080fd5b8235612f60816128a0565b91506020830135612b89816128a0565b600060608284031215612f8257600080fd5b610bd383836129c6565b600181811c90821680612fa057607f821691505b6020821081036128f357634e487b7160e01b600052602260045260246000fd5b600060208284031215612fd257600080fd5b8151610bd3816128a0565b600060208284031215612fef57600080fd5b5051919050565b634e487b7160e01b600052604160045260246000fd5b604051606081016001600160401b038111828210171561302e5761302e612ff6565b60405290565b604080519081016001600160401b038111828210171561302e5761302e612ff6565b604051601f8201601f191681016001600160401b038111828210171561307e5761307e612ff6565b604052919050565b60006001600160401b0382111561309f5761309f612ff6565b50601f01601f191660200190565b60006001600160401b03808411156130c7576130c7612ff6565b8360051b60206130d8818301613056565b8681529185019181810190368411156130f057600080fd5b865b848110156131b65780358681111561310a5760008081fd5b8801606036829003121561311e5760008081fd5b61312661300c565b61312f82612b00565b815261313c868301612bab565b86820152604080830135898111156131545760008081fd5b929092019136601f8401126131695760008081fd5b823561317c61317782613086565b613056565b81815236898387010111156131915760008081fd5b818986018a8301376000918101890191909152908201528452509183019183016130f2565b50979650505050505050565b600080858511156131d257600080fd5b838611156131df57600080fd5b5050820193919092039150565b600084516131fe81846020890161283d565b8201838582376000930192835250909392505050565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b602081526000610da7602083018486613214565b634e487b7160e01b600052603260045260246000fd5b6000823561013e1983360301811261327e57600080fd5b9190910192915050565b6000808335601e1984360301811261329f57600080fd5b8301803591506001600160401b038211156132b957600080fd5b602001915036819003821315612a1957600080fd5b6001600160401b038116811461141257600080fd5b63ffffffff6132f189612b00565b168152602088013560208201526000604089013561330e816132ce565b6001600160401b03811660408401525087606083015260e0608083015261333960e083018789613214565b6001600160a01b03861660a084015282810360c084015261335b818587613214565b9a9950505050505050505050565b60006020828403121561337b57600080fd5b81516001600160401b0381111561339157600080fd5b8201601f810184136133a257600080fd5b80516133b061317782613086565b8181528560208385010111156133c557600080fd5b611ac282602083016020860161283d565b6000602082840312156133e857600080fd5b8135610bd3816132ce565b60018060a01b038516815283602082015261ffff83166040820152608060608201526000610c5c6080830184612861565b6040815260006134376040830185612861565b8281036020840152611ac28185612861565b60006020828403121561345b57600080fd5b8151610bd381612b35565b6040815263ffffffff8351166040820152602083015160608201526000604084015160a0608084015261349c60e0840182612861565b90506060850151603f198483030160a08501526134b98282612861565b60809690960151151560c08501525050506001600160a01b039190911660209091015290565b6000604082840312156134f157600080fd5b6134f9613034565b9050815181526020820151602082015292915050565b60006040828403121561352157600080fd5b610bd383836134df565b601f821115611458576000816000526020600020601f850160051c810160208610156135545750805b601f850160051c820191505b8181101561357357828155600101613560565b505050505050565b81516001600160401b0381111561359457613594612ff6565b6135a8816135a28454612f8c565b8461352b565b602080601f8311600181146135dd57600084156135c55750858301515b600019600386901b1c1916600185901b178555613573565b600085815260208120601f198616915b8281101561360c578886015182559484019460019091019084016135ed565b508582101561362a5787850151600019600388901b60f8161c191681555b5050505050600190811b01905550565b600060208083018184528085518083526040925060408601915060408160051b87010184880160005b838110156136b757888303603f190185528151805163ffffffff1684528781015161ffff168885015286015160608785018190526136a381860183612861565b968901969450505090860190600101613663565b509098975050505050505050565b6000604082840312156136d757600080fd5b6136df613034565b82358152602083013560208201528091505092915050565b634e487b7160e01b600052601160045260246000fd5b60008261372a57634e487b7160e01b600052601260045260246000fd5b500490565b808202811582820484141761095d5761095d6136f7565b8035602083101561095d57600019602084900360031b1b1692915050565b6001600160c01b0319813581811691600885101561378c5780818660080360031b1b83161692505b505092915050565b6001600160401b0360c01b8560c01b16815263ffffffff60e01b8460e01b16600882015282600c820152600082516137d381602c85016020870161283d565b91909101602c0195945050505050565b8082018082111561095d5761095d6136f7565b8481526001600160401b0360c01b8460c01b1660208201528260288201526000825161382981604885016020870161283d565b9190910160480195945050505050565b60006080828403121561384b57600080fd5b61385361300c565b825181526020830151613865816132ce565b602082015261387784604085016134df565b60408201529392505050565b634e487b7160e01b600052602160045260246000fdfea2646970667358221220fb0c99fbe7683807cd1a918831e708e074a2b13b6c6c11bd8577cf86eb73720464736f6c63430008160033",
+  "devdoc": {
+    "errors": {
+      "ECDSAInvalidSignature()": [
+        {
+          "details": "The signature derives the `address(0)`."
+        }
+      ],
+      "ECDSAInvalidSignatureLength(uint256)": [
+        {
+          "details": "The signature has an invalid length."
+        }
+      ],
+      "ECDSAInvalidSignatureS(bytes32)": [
+        {
+          "details": "The signature has an S value that is in the upper half order."
+        }
+      ],
+      "ERC20InsufficientAllowance(address,uint256,uint256)": [
+        {
+          "details": "Indicates a failure with the `spender`’s `allowance`. Used in transfers.",
+          "params": {
+            "allowance": "Amount of tokens a `spender` is allowed to operate with.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC20InsufficientBalance(address,uint256,uint256)": [
+        {
+          "details": "Indicates an error related to the current `balance` of a `sender`. Used in transfers.",
+          "params": {
+            "balance": "Current balance for the interacting account.",
+            "needed": "Minimum amount required to perform a transfer.",
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidApprover(address)": [
+        {
+          "details": "Indicates a failure with the `approver` of a token to be approved. Used in approvals.",
+          "params": {
+            "approver": "Address initiating an approval operation."
+          }
+        }
+      ],
+      "ERC20InvalidReceiver(address)": [
+        {
+          "details": "Indicates a failure with the token `receiver`. Used in transfers.",
+          "params": {
+            "receiver": "Address to which tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSender(address)": [
+        {
+          "details": "Indicates a failure with the token `sender`. Used in transfers.",
+          "params": {
+            "sender": "Address whose tokens are being transferred."
+          }
+        }
+      ],
+      "ERC20InvalidSpender(address)": [
+        {
+          "details": "Indicates a failure with the `spender` to be approved. Used in approvals.",
+          "params": {
+            "spender": "Address that may be allowed to operate on tokens without being their owner."
+          }
+        }
+      ],
+      "ERC2612ExpiredSignature(uint256)": [
+        {
+          "details": "Permit deadline has expired."
+        }
+      ],
+      "ERC2612InvalidSigner(address,address)": [
+        {
+          "details": "Mismatched signature."
+        }
+      ],
+      "InvalidAccountNonce(address,uint256)": [
+        {
+          "details": "The nonce used for an `account` is not the expected current nonce."
+        }
+      ],
+      "OwnableInvalidOwner(address)": [
+        {
+          "details": "The owner is not a valid owner account. (eg. `address(0)`)"
+        }
+      ],
+      "OwnableUnauthorizedAccount(address)": [
+        {
+          "details": "The caller account is not authorized to perform an operation."
+        }
+      ],
+      "SafeERC20FailedOperation(address)": [
+        {
+          "details": "An operation with an ERC-20 token failed."
+        }
+      ]
+    },
+    "events": {
+      "Approval(address,address,uint256)": {
+        "details": "Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance."
+      },
+      "EIP712DomainChanged()": {
+        "details": "MAY be emitted to signal that the domain could have changed."
+      },
+      "PreCrimeSet(address)": {
+        "details": "Emitted when the preCrime contract address is set.",
+        "params": {
+          "preCrimeAddress": "The address of the preCrime contract."
+        }
+      },
+      "Transfer(address,address,uint256)": {
+        "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero."
+      }
+    },
+    "kind": "dev",
+    "methods": {
+      "DOMAIN_SEPARATOR()": {
+        "details": "Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}."
+      },
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "details": "This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.This defaults to assuming if a peer has been set, its initialized. Can be overridden by the OApp if there is other logic to determine this.",
+        "params": {
+          "origin": "The origin information containing the source endpoint and sender address."
+        },
+        "returns": {
+          "_0": "Whether the path has been initialized."
+        }
+      },
+      "allowance(address,address)": {
+        "details": "See {IERC20-allowance}."
+      },
+      "approvalRequired()": {
+        "details": "In the case of OFT where the contract IS the token, approval is NOT required.",
+        "returns": {
+          "_0": "requiresApproval Needs approval of the underlying token implementation."
+        }
+      },
+      "approve(address,uint256)": {
+        "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+      },
+      "balanceOf(address)": {
+        "details": "See {IERC20-balanceOf}."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "details": "If there is an enforced lzReceive option: - {gasLimit: 200k, msg.value: 1 ether} AND a caller supplies a lzReceive option: {gasLimit: 100k, msg.value: 0.5 ether} - The resulting options will be {gasLimit: 300k, msg.value: 1.5 ether} when the message is executed on the remote lzReceive() function.This presence of duplicated options is handled off-chain in the verifier/executor.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_extraOptions": "Additional options passed by the caller.",
+          "_msgType": "The OAPP message type."
+        },
+        "returns": {
+          "_0": "options The combination of caller specified options AND enforced options."
+        }
+      },
+      "constructor": {
+        "details": "Using msg.sender instead of _delegate in Ownable to avoid via-ir"
+      },
+      "decimals()": {
+        "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+      },
+      "eip712Domain()": {
+        "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "details": "_origin The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message._message The lzReceive payload.Applications can optionally choose to implement separate composeMsg senders that are NOT the bridging layer.The default sender IS the OAppReceiver implementer.",
+        "params": {
+          "_sender": "The sender address."
+        },
+        "returns": {
+          "_0": "isSender Is a valid sender."
+        }
+      },
+      "isPeer(uint32,bytes32)": {
+        "details": "Check if the peer is considered 'trusted' by the OApp.Enables OAppPreCrimeSimulator to check whether a potential Inbound Packet is from a trusted source.",
+        "params": {
+          "_eid": "The endpoint ID to check.",
+          "_peer": "The peer to check."
+        },
+        "returns": {
+          "_0": "Whether the peer passed is considered 'trusted' by the OApp."
+        }
+      },
+      "lzReceive((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Entry point for receiving messages or packets from the endpoint.Entry point for receiving msg/packet from the LayerZero endpoint.",
+        "params": {
+          "_executor": "The address of the executor for the received message.",
+          "_extraData": "Additional arbitrary data provided by the corresponding executor.",
+          "_guid": "The unique identifier for the received LayerZero message.",
+          "_message": "The payload of the received message.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "lzReceiveAndRevert(((uint32,bytes32,uint64),uint32,address,bytes32,uint256,address,bytes,bytes)[])": {
+        "details": "Interface for pre-crime simulations. Always reverts at the end with the simulation results.WARNING: MUST revert at the end with the simulation results.Gives the preCrime implementation the ability to mock sending packets to the lzReceive function, WITHOUT actually executing them.",
+        "params": {
+          "_packets": "An array of InboundPacket objects representing received packets to be delivered."
+        }
+      },
+      "lzReceiveSimulate((uint32,bytes32,uint64),bytes32,bytes,address,bytes)": {
+        "details": "Is effectively an internal function because msg.sender must be address(this). Allows resetting the call stack for 'internal' calls.",
+        "params": {
+          "_executor": "The executor address for the packet.",
+          "_extraData": "Additional data for the packet.",
+          "_guid": "The unique identifier of the packet.",
+          "_message": "The message payload of the packet.",
+          "_origin": "The origin information containing the source endpoint and sender address.  - srcEid: The source chain endpoint ID.  - sender: The sender address on the src chain.  - nonce: The nonce of the message."
+        }
+      },
+      "name()": {
+        "details": "Returns the name of the token."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "details": "_srcEid The source endpoint ID._sender The sender address.The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.Is required by the off-chain executor to determine the OApp expects msg execution is ordered.This is also enforced by the OApp.By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.",
+        "returns": {
+          "nonce": "The next nonce."
+        }
+      },
+      "nonces(address)": {
+        "details": "Returns the current nonce for `owner`. This value must be included whenever a signature is generated for {permit}. Every successful call to {permit} increases ``owner``'s nonce by one. This prevents a signature from being used multiple times."
+      },
+      "oApp()": {
+        "details": "Retrieves the address of the OApp contract.The simulator contract is the base contract for the OApp by default.If the simulator is a separate contract, override this function.",
+        "returns": {
+          "_0": "The address of the OApp contract."
+        }
+      },
+      "oAppVersion()": {
+        "returns": {
+          "receiverVersion": "The version of the OAppReceiver.sol implementation.",
+          "senderVersion": "The version of the OAppSender.sol implementation."
+        }
+      },
+      "oftVersion()": {
+        "details": "interfaceId: This specific interface ID is '0x02e49c2c'.version: Indicates a cross-chain compatible msg encoding with other OFTs.If a new feature is added to the OFT cross-chain msg encoding, the version will be incremented. ie. localOFT version(x,1) CAN send messages to remoteOFT version(x,1)",
+        "returns": {
+          "interfaceId": "The interface ID.",
+          "version": "The version."
+        }
+      },
+      "owner()": {
+        "details": "Returns the address of the current owner."
+      },
+      "permit(address,address,uint256,uint256,uint8,bytes32,bytes32)": {
+        "details": "Sets `value` as the allowance of `spender` over ``owner``'s tokens, given ``owner``'s signed approval. IMPORTANT: The same issues {IERC20-approve} has related to transaction ordering also apply here. Emits an {Approval} event. Requirements: - `spender` cannot be the zero address. - `deadline` must be a timestamp in the future. - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner` over the EIP712-formatted function arguments. - the signature must use ``owner``'s current nonce (see {nonces}). For more information on the signature format, see the https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section]. CAUTION: See Security Considerations above."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "params": {
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "oftFeeDetails": "The details of OFT fees.",
+          "oftLimit": "The OFT limit information.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "details": "MessagingFee: LayerZero msg fee  - nativeFee: The native fee.  - lzTokenFee: The lzToken fee.",
+        "params": {
+          "_payInLzToken": "Flag indicating whether the caller is paying in the LZ token.",
+          "_sendParam": "The parameters for the send() operation."
+        },
+        "returns": {
+          "msgFee": "The calculated LayerZero messaging fee from the send() operation."
+        }
+      },
+      "renounceOwnership()": {
+        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+      },
+      "send((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)": {
+        "details": "Executes the send operation.MessagingReceipt: LayerZero msg receipt  - guid: The unique identifier for the sent message.  - nonce: The nonce of the sent message.  - fee: The LayerZero fee incurred for the message.",
+        "params": {
+          "_fee": "The calculated fee for the send() operation.      - nativeFee: The native fee.      - lzTokenFee: The lzToken fee.",
+          "_refundAddress": "The address to receive any excess funds.",
+          "_sendParam": "The parameters for the send operation."
+        },
+        "returns": {
+          "msgReceipt": "The receipt for the send operation.",
+          "oftReceipt": "The OFT receipt information."
+        }
+      },
+      "setDelegate(address)": {
+        "details": "Only the owner/admin of the OApp can call this function.Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.",
+        "params": {
+          "_delegate": "The address of the delegate to be set."
+        }
+      },
+      "setEnforcedOptions((uint32,uint16,bytes)[])": {
+        "details": "Sets the enforced options for specific endpoint and message type combinations.Only the owner/admin of the OApp can call this function.Provides a way for the OApp to enforce things like paying for PreCrime, AND/OR minimum dst lzReceive gas amounts etc.These enforced options can vary as the potential options/execution on the remote may differ as per the msgType. eg. Amount of lzReceive() gas necessary to deliver a lzCompose() message adds overhead you dont want to pay if you are only making a standard LayerZero message ie. lzReceive() WITHOUT sendCompose().",
+        "params": {
+          "_enforcedOptions": "An array of EnforcedOptionParam structures specifying enforced options."
+        }
+      },
+      "setMsgInspector(address)": {
+        "details": "Sets the message inspector address for the OFT.This is an optional contract that can be used to inspect both 'message' and 'options'.Set it to address(0) to disable it, or set it to a contract address to enable it.",
+        "params": {
+          "_msgInspector": "The address of the message inspector."
+        }
+      },
+      "setPeer(uint32,bytes32)": {
+        "details": "Only the owner/admin of the OApp can call this function.Indicates that the peer is trusted to send LayerZero messages to this OApp.Set this to bytes32(0) to remove the peer address.Peer is a bytes32 to accommodate non-evm chains.",
+        "params": {
+          "_eid": "The endpoint ID.",
+          "_peer": "The address of the peer to be associated with the corresponding endpoint."
+        }
+      },
+      "setPreCrime(address)": {
+        "details": "Sets the preCrime contract address.",
+        "params": {
+          "_preCrime": "The address of the preCrime contract."
+        }
+      },
+      "sharedDecimals()": {
+        "details": "Retrieves the shared decimals of the OFT.Sets an implicit cap on the amount of tokens, over uint64.max() will need some sort of outbound cap / totalSupply cap Lowest common decimal denominator between chains. Defaults to 6 decimal places to provide up to 18,446,744,073,709.551615 units (max uint64). For tokens exceeding this totalSupply(), they will need to override the sharedDecimals function with something smaller. ie. 4 sharedDecimals would be 1,844,674,407,370,955.1615",
+        "returns": {
+          "_0": "The shared decimals of the OFT."
+        }
+      },
+      "symbol()": {
+        "details": "Returns the symbol of the token, usually a shorter version of the name."
+      },
+      "token()": {
+        "details": "Retrieves the address of the underlying ERC20 implementation.In the case of OFT, address(this) and erc20 are the same contract.",
+        "returns": {
+          "_0": "The address of the OFT token."
+        }
+      },
+      "totalSupply()": {
+        "details": "See {IERC20-totalSupply}."
+      },
+      "transfer(address,uint256)": {
+        "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+      },
+      "transferFrom(address,address,uint256)": {
+        "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+      },
+      "transferOwnership(address)": {
+        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "allowInitializePath((uint32,bytes32,uint64))": {
+        "notice": "Checks if the path initialization is allowed based on the provided origin."
+      },
+      "approvalRequired()": {
+        "notice": "Indicates whether the OFT contract requires approval of the 'token()' to send."
+      },
+      "combineOptions(uint32,uint16,bytes)": {
+        "notice": "Combines options for a given endpoint and message type."
+      },
+      "endpoint()": {
+        "notice": "Retrieves the LayerZero endpoint associated with the OApp."
+      },
+      "isComposeMsgSender((uint32,bytes32,uint64),bytes,address)": {
+        "notice": "Indicates whether an address is an approved composeMsg sender to the Endpoint."
+      },
+      "nextNonce(uint32,bytes32)": {
+        "notice": "Retrieves the next nonce for a given source endpoint and sender address."
+      },
+      "oAppVersion()": {
+        "notice": "Retrieves the OApp version information."
+      },
+      "oftVersion()": {
+        "notice": "Retrieves interfaceID and the version of the OFT."
+      },
+      "peers(uint32)": {
+        "notice": "Retrieves the peer (OApp) associated with a corresponding endpoint."
+      },
+      "quoteOFT((uint32,bytes32,uint256,uint256,bytes,bytes,bytes))": {
+        "notice": "Provides the fee breakdown and settings data for an OFT. Unused in the default implementation."
+      },
+      "quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)": {
+        "notice": "Provides a quote for the send() operation."
+      },
+      "setDelegate(address)": {
+        "notice": "Sets the delegate address for the OApp."
+      },
+      "setPeer(uint32,bytes32)": {
+        "notice": "Sets the peer address (OApp instance) for a corresponding endpoint."
+      }
+    },
+    "version": 1
+  },
+  "storageLayout": {
+    "storage": [
+      {
+        "astId": 3971,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_owner",
+        "offset": 0,
+        "slot": "0",
+        "type": "t_address"
+      },
+      {
+        "astId": 1390,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "peers",
+        "offset": 0,
+        "slot": "1",
+        "type": "t_mapping(t_uint32,t_bytes32)"
+      },
+      {
+        "astId": 2166,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "preCrime",
+        "offset": 0,
+        "slot": "2",
+        "type": "t_address"
+      },
+      {
+        "astId": 2006,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "enforcedOptions",
+        "offset": 0,
+        "slot": "3",
+        "type": "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))"
+      },
+      {
+        "astId": 2916,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "msgInspector",
+        "offset": 0,
+        "slot": "4",
+        "type": "t_address"
+      },
+      {
+        "astId": 4385,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_balances",
+        "offset": 0,
+        "slot": "5",
+        "type": "t_mapping(t_address,t_uint256)"
+      },
+      {
+        "astId": 4391,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_allowances",
+        "offset": 0,
+        "slot": "6",
+        "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))"
+      },
+      {
+        "astId": 4393,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_totalSupply",
+        "offset": 0,
+        "slot": "7",
+        "type": "t_uint256"
+      },
+      {
+        "astId": 4395,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_name",
+        "offset": 0,
+        "slot": "8",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 4397,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_symbol",
+        "offset": 0,
+        "slot": "9",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7913,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nameFallback",
+        "offset": 0,
+        "slot": "10",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 7915,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_versionFallback",
+        "offset": 0,
+        "slot": "11",
+        "type": "t_string_storage"
+      },
+      {
+        "astId": 5679,
+        "contract": "contracts/GM/MarketToken_OFT.sol:MarketToken_OFT",
+        "label": "_nonces",
+        "offset": 0,
+        "slot": "12",
+        "type": "t_mapping(t_address,t_uint256)"
+      }
+    ],
+    "types": {
+      "t_address": {
+        "encoding": "inplace",
+        "label": "address",
+        "numberOfBytes": "20"
+      },
+      "t_bytes32": {
+        "encoding": "inplace",
+        "label": "bytes32",
+        "numberOfBytes": "32"
+      },
+      "t_bytes_storage": {
+        "encoding": "bytes",
+        "label": "bytes",
+        "numberOfBytes": "32"
+      },
+      "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => mapping(address => uint256))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_address,t_uint256)"
+      },
+      "t_mapping(t_address,t_uint256)": {
+        "encoding": "mapping",
+        "key": "t_address",
+        "label": "mapping(address => uint256)",
+        "numberOfBytes": "32",
+        "value": "t_uint256"
+      },
+      "t_mapping(t_uint16,t_bytes_storage)": {
+        "encoding": "mapping",
+        "key": "t_uint16",
+        "label": "mapping(uint16 => bytes)",
+        "numberOfBytes": "32",
+        "value": "t_bytes_storage"
+      },
+      "t_mapping(t_uint32,t_bytes32)": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => bytes32)",
+        "numberOfBytes": "32",
+        "value": "t_bytes32"
+      },
+      "t_mapping(t_uint32,t_mapping(t_uint16,t_bytes_storage))": {
+        "encoding": "mapping",
+        "key": "t_uint32",
+        "label": "mapping(uint32 => mapping(uint16 => bytes))",
+        "numberOfBytes": "32",
+        "value": "t_mapping(t_uint16,t_bytes_storage)"
+      },
+      "t_string_storage": {
+        "encoding": "bytes",
+        "label": "string",
+        "numberOfBytes": "32"
+      },
+      "t_uint16": {
+        "encoding": "inplace",
+        "label": "uint16",
+        "numberOfBytes": "2"
+      },
+      "t_uint256": {
+        "encoding": "inplace",
+        "label": "uint256",
+        "numberOfBytes": "32"
+      },
+      "t_uint32": {
+        "encoding": "inplace",
+        "label": "uint32",
+        "numberOfBytes": "4"
+      }
+    }
+  }
+}

--- a/devtools/config/tokens.ts
+++ b/devtools/config/tokens.ts
@@ -51,6 +51,28 @@ const WBTC_USDC: MarketPairConfig = {
     },
 }
 
+const WETH_WETH: MarketPairConfig = {
+    GM: {
+        tokenSymbol: 'GM: ETH/USD [WETH-WETH]',
+        hubNetwork: {
+            eid: EndpointId.ARBITRUM_V2_MAINNET,
+            contractAddress: '0x450bb6774Dd8a756274E0ab4107953259d2ac541',
+        },
+        expansionNetworks: ExpansionNetworks.mainnet,
+    },
+}
+
+const BTC_BTC: MarketPairConfig = {
+    GM: {
+        tokenSymbol: 'GM: BTC/USD [BTC-BTC]',
+        hubNetwork: {
+            eid: EndpointId.ARBITRUM_V2_MAINNET,
+            contractAddress: '0x7C11F78Ce78768518D743E81Fdfa2F860C6b9A77',
+        },
+        expansionNetworks: ExpansionNetworks.mainnet,
+    },
+}
+
 const WETH_USDC_SG: MarketPairConfig = {
     GM: {
         tokenSymbol: 'GM WETH-USDC.SG',
@@ -76,5 +98,7 @@ const WETH_USDC_SG: MarketPairConfig = {
 export const Tokens: Config = {
     WETH_USDC,
     WBTC_USDC,
+    WETH_WETH,
+    BTC_BTC,
     WETH_USDC_SG,
 }

--- a/devtools/types.ts
+++ b/devtools/types.ts
@@ -22,8 +22,8 @@ export interface TokenConfig {
  * Market pair configuration containing both GM and GLV tokens
  */
 export interface MarketPairConfig {
-    GM: TokenConfig
-    GLV: TokenConfig
+    GM?: TokenConfig
+    GLV?: TokenConfig
 }
 
 /**

--- a/devtools/wire/wire-generator.ts
+++ b/devtools/wire/wire-generator.ts
@@ -98,6 +98,13 @@ export async function generateWireConfig(
 
     // Determine token type and contract names
     const tokenConfig = contractType === 'GlvToken' ? config.GLV : config.GM
+    
+    if (!tokenConfig) {
+        throw new Error(
+            `${contractType === 'GlvToken' ? 'GLV' : 'GM'} token is not configured for this market pair`
+        )
+    }
+    
     const adapterContractName = `${contractType}_Adapter_${key}`
     const oftContractName = `${contractType}_OFT_${key}`
 

--- a/tasks/display-deployments.ts
+++ b/tasks/display-deployments.ts
@@ -4,6 +4,40 @@ import path from 'path'
 import { task } from 'hardhat/config'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
+/**
+ * Block explorer URLs for each network
+ */
+const BLOCK_EXPLORERS: Record<string, string> = {
+    'arbitrum-mainnet': 'https://arbiscan.io/address',
+    'base-mainnet': 'https://basescan.org/address',
+    'bera-mainnet': 'https://berascan.com/address',
+    'botanix-mainnet': 'https://botanixscan.io/address',
+    'bsc-mainnet': 'https://bscscan.com/address',
+    'ethereum-mainnet': 'https://etherscan.io/address',
+    'arbitrum-testnet': 'https://sepolia.arbiscan.io/address',
+    'ethereum-testnet': 'https://sepolia.etherscan.io/address',
+}
+
+/**
+ * Creates a clickable terminal link (works in most modern terminals)
+ */
+function createClickableLink(text: string, url: string): string {
+    // ANSI escape code for hyperlinks: \x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\
+    return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`
+}
+
+/**
+ * Formats an address with a clickable link to block explorer
+ */
+function formatAddressLink(address: string, network: string): string {
+    const explorerBase = BLOCK_EXPLORERS[network]
+    if (explorerBase) {
+        const url = `${explorerBase}/${address}`
+        return createClickableLink(address, url)
+    }
+    return address // No link if explorer not configured
+}
+
 interface DeploymentInfo {
     network: string
     address: string
@@ -101,7 +135,8 @@ const displayDeployments = task(
                 console.log('     (none)')
             } else {
                 deployments.GM.forEach((dep) => {
-                    console.log(`     ${dep.network}: ${dep.address} (${dep.contractType})`)
+                    const addressLink = formatAddressLink(dep.address, dep.network)
+                    console.log(`     ${dep.network}: ${addressLink} (${dep.contractType})`)
                 })
             }
 
@@ -111,7 +146,8 @@ const displayDeployments = task(
                 console.log('     (none)')
             } else {
                 deployments.GLV.forEach((dep) => {
-                    console.log(`     ${dep.network}: ${dep.address} (${dep.contractType})`)
+                    const addressLink = formatAddressLink(dep.address, dep.network)
+                    console.log(`     ${dep.network}: ${addressLink} (${dep.contractType})`)
                 })
             }
 

--- a/tasks/ownership-wrapper.ts
+++ b/tasks/ownership-wrapper.ts
@@ -151,7 +151,8 @@ const transferOwnership = task(
                 )
             } else {
                 // Transfer ownership for both GM and GLV
-                const tokenTypes: ('GM' | 'GLV')[] = ['GM', 'GLV']
+                const { getAvailableTokenTypes } = await import('../devtools/deploy/utils')
+                const tokenTypes = await getAvailableTokenTypes(marketPair)
 
                 for (const type of tokenTypes) {
                     // Determine signer based on token type

--- a/tasks/validate-config.ts
+++ b/tasks/validate-config.ts
@@ -81,8 +81,8 @@ function formatTable(results: ValidationResult[]): void {
     console.log('\nConfiguration Validation Results')
 
     const table = new CliTable3.default({
-        head: ['Market Pair', 'Contract Address', 'Config Symbol', 'On-Chain Symbol', 'Symbol', 'Decimals'],
-        colWidths: [16, 44, 25, 25, 8, 10],
+        head: ['Market Pair', 'Type', 'Contract Address', 'On-Chain Symbol', 'Match', 'Decimals'],
+        colWidths: [16, 6, 44, 20, 7, 10],
         wordWrap: true,
         wrapOnWordBoundary: false,
     })
@@ -90,8 +90,8 @@ function formatTable(results: ValidationResult[]): void {
     results.forEach((result) => {
         table.push([
             result.marketPair,
+            result.tokenType,
             result.contractAddress,
-            result.configSymbol,
             result.onChainSymbol,
             result.symbolMatch ? '✅' : '❌',
             result.decimals.toString(),
@@ -101,20 +101,34 @@ function formatTable(results: ValidationResult[]): void {
     console.log(table.toString())
 
     // Summary
-    const glvMismatches = results.filter((r) => !r.symbolMatch)
+    const gmResults = results.filter((r) => r.tokenType === 'GM')
+    const glvResults = results.filter((r) => r.tokenType === 'GLV')
+    const mismatches = results.filter((r) => !r.symbolMatch)
+    const gmMismatches = mismatches.filter((r) => r.tokenType === 'GM')
+    const glvMismatches = mismatches.filter((r) => r.tokenType === 'GLV')
 
     console.log('\nSummary:')
-    console.log(`   GLV tokens validated: ${results.length}`)
-    console.log(`   GLV mismatches: ${glvMismatches.length}`)
+    console.log(`   Total tokens validated: ${results.length}`)
+    if (gmResults.length > 0) console.log(`     GM tokens: ${gmResults.length}`)
+    if (glvResults.length > 0) console.log(`     GLV tokens: ${glvResults.length}`)
+    console.log(`   Total mismatches: ${mismatches.length}`)
 
-    if (glvMismatches.length > 0) {
-        console.log('\n⚠️  GLV Token Mismatches (these need attention):')
-        glvMismatches.forEach((result) => {
-            console.log(`   ${result.marketPair} GLV:`)
-            console.log(`     Symbol: "${result.configSymbol}" ≠ "${result.onChainSymbol}"`)
-        })
+    if (mismatches.length > 0) {
+        console.log('\n⚠️  Token Mismatches (these need attention):')
+        if (gmMismatches.length > 0) {
+            console.log('   GM Tokens (should be "GM"):')
+            gmMismatches.forEach((result) => {
+                console.log(`     ${result.marketPair}: on-chain symbol is "${result.onChainSymbol}" (expected "GM")`)
+            })
+        }
+        if (glvMismatches.length > 0) {
+            console.log('   GLV Tokens (should match config):')
+            glvMismatches.forEach((result) => {
+                console.log(`     ${result.marketPair}: "${result.configSymbol}" ≠ "${result.onChainSymbol}"`)
+            })
+        }
     } else {
-        console.log('   ✅ All GLV tokens match their on-chain counterparts!')
+        console.log('   ✅ All tokens match their expected on-chain values!')
     }
 }
 
@@ -137,7 +151,15 @@ task('lz:sdk:validate-config', 'Validates the devtools configuration against on-
 
         // First, validate that hub networks are not in expansion networks
         console.log('🔍 Validating configuration structure...')
-        for (const [marketPairKey, marketPairConfig] of Object.entries(Tokens)) {
+        const tokensToValidate = filterMarketPair
+            ? { [filterMarketPair]: Tokens[filterMarketPair] }
+            : Tokens
+
+        if (filterMarketPair && !tokensToValidate[filterMarketPair]) {
+            throw new Error(`Market pair '${filterMarketPair}' not found. Available: ${Object.keys(Tokens).join(', ')}`)
+        }
+
+        for (const [marketPairKey, marketPairConfig] of Object.entries(tokensToValidate)) {
             try {
                 validateHubNetworksNotInExpansion(marketPairConfig)
                 console.log(`✅ ${marketPairKey}: Configuration structure valid`)
@@ -148,24 +170,46 @@ task('lz:sdk:validate-config', 'Validates the devtools configuration against on-
         }
 
         console.log('\n🔍 Validating on-chain token data...')
+        console.log('ℹ️  GM tokens: Checking that on-chain name is "GM" (hub uses generic name)')
+        console.log('ℹ️  GLV tokens: Checking that on-chain name matches config name\n')
+        
         const results: ValidationResult[] = []
 
         // Process each market pair in the config
-        for (const [marketPairKey, marketPairConfig] of Object.entries(Tokens)) {
-            // Only validate if GLV is configured
-            if (!marketPairConfig.GLV) {
-                console.log(`⏭️  Skipping ${marketPairKey} - no GLV token configured`)
-                continue
+        for (const [marketPairKey, marketPairConfig] of Object.entries(tokensToValidate)) {
+            // Validate GM token if configured and not filtered out
+            if (marketPairConfig.GM && (!filterTokenType || filterTokenType === 'GM')) {
+                console.log(`📈 Processing ${marketPairKey} GM...`)
+                try {
+                    const gmResult = await validateTokenConfig(hre, marketPairKey, 'GM', marketPairConfig.GM)
+                    // For GM tokens, we expect on-chain name to be "GM"
+                    gmResult.symbolMatch = gmResult.onChainSymbol === 'GM'
+                    results.push(gmResult)
+                } catch (error) {
+                    console.error(`   ❌ Error validating ${marketPairKey} GM:`, error)
+                }
             }
-            
-            console.log(`📈 Processing ${marketPairKey} GLV...`)
 
-            try {
-                // Validate GLV token only
-                const glvResult = await validateTokenConfig(hre, marketPairKey, 'GLV', marketPairConfig.GLV)
-                results.push(glvResult)
-            } catch (error) {
-                console.error(`   ❌ Error validating ${marketPairKey} GLV:`, error)
+            // Validate GLV token if configured and not filtered out
+            if (marketPairConfig.GLV && (!filterTokenType || filterTokenType === 'GLV')) {
+                console.log(`📈 Processing ${marketPairKey} GLV...`)
+                try {
+                    const glvResult = await validateTokenConfig(hre, marketPairKey, 'GLV', marketPairConfig.GLV)
+                    results.push(glvResult)
+                } catch (error) {
+                    console.error(`   ❌ Error validating ${marketPairKey} GLV:`, error)
+                }
+            }
+
+            // Log if neither is configured or both filtered out
+            const hasGM = marketPairConfig.GM && (!filterTokenType || filterTokenType === 'GM')
+            const hasGLV = marketPairConfig.GLV && (!filterTokenType || filterTokenType === 'GLV')
+            if (!hasGM && !hasGLV) {
+                if (filterTokenType) {
+                    console.log(`⏭️  Skipping ${marketPairKey} - no ${filterTokenType} token configured`)
+                } else {
+                    console.log(`⏭️  Skipping ${marketPairKey} - no tokens configured`)
+                }
             }
         }
 

--- a/tasks/vape-send-tokens.ts
+++ b/tasks/vape-send-tokens.ts
@@ -50,6 +50,10 @@ const sendTokens = task('lz:sdk:vape:send-tokens', 'Send tokens to all peer netw
             // Get deployment config
             const { marketPairConfig } = await getDeployConfig()
             const tokenConfig = tokenType === 'GM' ? marketPairConfig.GM : marketPairConfig.GLV
+            
+            if (!tokenConfig) {
+                throw new Error(`${tokenType} token is not configured for market pair ${marketPair}`)
+            }
 
             // Get current network EID
             const currentNetworkEid = (hre.network.config as { eid?: number }).eid

--- a/tasks/wire-wrapper.ts
+++ b/tasks/wire-wrapper.ts
@@ -199,7 +199,8 @@ const wire = task('lz:sdk:wire', 'Wire LayerZero contracts with automatic config
                 )
             } else {
                 // Wire both GM and GLV
-                const tokenTypes: ('GM' | 'GLV')[] = ['GM', 'GLV']
+                const { getAvailableTokenTypes } = await import('../devtools/deploy/utils')
+                const tokenTypes = await getAvailableTokenTypes(marketPair)
 
                 for (const type of tokenTypes) {
                     // Determine signer based on token type


### PR DESCRIPTION
Updated config with `BTC-BTC` and `WETH-WETH` GM markets

GM: ETH/USD [WETH-WETH] - 0x450bb6774Dd8a756274E0ab4107953259d2ac541

GM: BTC/USDC [BTC-BTC] - 0x7C11F78Ce78768518D743E81Fdfa2F860C6b9A77

on arbitrum (as OFTAdapter), and OFTs on Base, Bera, Botanix, BSC, and Ethereum.

deployed, wired, and transfer ownership after running validation scripts to assert that config is set right.

## Deployments 
```
BTC-BTC
   GM Tokens:
     arbitrum-mainnet: 0x661E1faD17124471a59c37E9c4590BA809599f30 (Adapter)
     base-mainnet: 0x5E922D32c7278f6c5621a016c03055c54C97D27b (OFT)
     bera-mainnet: 0xa2d2e356c64dE9b0a5b4CFDfF2B4c82C0eC3D7A2 (OFT)
     botanix-mainnet: 0x9717D91D6943546A990Ae509a46655BA4Ad57649 (OFT)
     bsc-mainnet: 0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1 (OFT)
     ethereum-mainnet: 0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C (OFT)
```

```
WETH-WETH
   GM Tokens:
     arbitrum-mainnet: 0x0110424A21D5DF818f4a789E5d9d9141a4E29A3C (Adapter)
     base-mainnet: 0x47dFf0cbE239c02479C5944b9F4F3Ade8a212457 (OFT)
     bera-mainnet: 0x2e6Bf9Bdd2A7872bDae170C13F34d64692f842C1 (OFT)
     botanix-mainnet: 0x9f260cf66B3240e75C1bEe51a65936b513618159 (OFT)
     bsc-mainnet: 0x5Ece4d3F43D3BD8cBffc1d2CE851E7605D403D3C (OFT)
     ethereum-mainnet: 0x0B335e18Ab68Ccd2E8946A6E785D8bE65F413103 (OFT)
```

## Validation

```
$ npx hardhat lz:sdk:validate-deployments --market-pair BTC_BTC 
$ npx hardhat lz:sdk:validate-deployments --market-pair WETH_WETH

```

## SDK updates
Updated some helper scripts to make GM or GLV optional and print block-explorer links in display-deployments task. 

Signed-off-by: shankar <shankar@layerzerolabs.org>